### PR TITLE
Mailing sometimes failed because of non-escaped slashes 

### DIFF
--- a/nzbget-postprocessing-files/9.0/bin/nzbget-postprocess.sh
+++ b/nzbget-postprocessing-files/9.0/bin/nzbget-postprocess.sh
@@ -160,9 +160,9 @@ replaceVarBy() {
 
 	# If we're not using Bash use sed, as we need to support as much as systems possible, also those running sh/dash etc
 	if [ -n "${BASH_VERSION}" ]; then
-		REPLACEDRESULT="${1/${2}/${3}}"
+		REPLACEDRESULT="${1/${2}/${3##*/}}" # get last part after slash for paths
 	else
-		REPLACEDRESULT=$(echo "${1}" | sed "s/${2}/${3}/")
+		REPLACEDRESULT=$(echo "${1}" | sed "s/${2}/${3##*/}/") # get last part after slash for paths
 	fi
 
 	if [ "$Debug" = "yes" ]; then echo "[DETAIL] Post-Process: replace result: ${REPLACEDRESULT}" ; fi


### PR DESCRIPTION
When trying to mail if one of the arguments contains a slash an empty mail would be send. This happens mostly if a postprocessing script is set.

The fix is to show the filename only (not the full path). I couldn't get the slashes to escape properly. As the escaped string would have to be escaped as well before it's used and after a while I lost track of the amount of regular slashes and escaped slashes to use. I'd see this as a temporary solution.

We have to find a nice way to escape, as the bug will still occur if the template of the mail contains slashes. If someone has suggestions for this, don't hesitate to contact me so we can find a solution that's more permanent.
