### PR TITLE
Bugfix :: autoProcessTV.py : 404 html error

### DIFF
--- a/autoProcessTV.py
+++ b/autoProcessTV.py
@@ -110,7 +110,7 @@ def processEpisode(dirName, nzbName=None, failed=False):
                 
     # this is our default behaviour to work with the standard Master branch of SickBeard
     else:
-        params['dir'] = dirName
+        params['dirName'] = dirName
         if nzbName != None:
             params['nzbName'] = nzbName
         # the standard Master bamch of SickBeard cannot process failed downloads. So Exit here.


### PR DESCRIPTION
Bugfix :: autoProcessTV.py : Typo in parameter name which leads to a 404 page when attempting to process without failed fork.
