### PR TITLE
Added support for symbolic linking.

### DIFF
--- a/TorrentToMedia.py
+++ b/TorrentToMedia.py
@@ -143,7 +143,7 @@ def main(inputDirectory, inputName, inputCategory, inputHash, inputID):
             Logger.error("MAIN: Failed to connect to uTorrent: %s", e)
 
         # if we are using links with uTorrent it means we need to pause it in order to access the files
-        if useLink == 1:
+        if useLink != "no":
             Logger.debug("MAIN: Stoping torrent %s in uTorrent while processing", inputName)
             utorrentClass.stop(inputHash)
             time.sleep(5)  # Give uTorrent some time to catch up with the change
@@ -192,7 +192,7 @@ def main(inputDirectory, inputName, inputCategory, inputHash, inputID):
         Logger.info("MAIN: A problem was reported in the autoProcess* script. If torrent was pasued we will resume seeding")
 
     # Hardlink solution for uTorrent, need to implent support for deluge, transmission
-    if clientAgent == 'utorrent' and extractionSuccess == False and inputHash and useLink == 1 and deleteOriginal == 0: # we always want to resume seeding, for now manually find out what is wrong when extraction fails
+    if clientAgent == 'utorrent' and extractionSuccess == False and inputHash and useLink != "no" and deleteOriginal == 0: # we always want to resume seeding, for now manually find out what is wrong when extraction fails
         Logger.debug("MAIN: Starting torrent %s in uTorrent", inputName)
         utorrentClass.start(inputHash)
 
@@ -225,7 +225,7 @@ if __name__ == "__main__":
     config.read(configFilename)
                                                                                         # EXAMPLE VALUES:
     clientAgent = config.get("Torrent", "clientAgent")                                  # utorrent | deluge | transmission | other
-    useLink = int(config.get("Torrent", "useLink"))                                     # true | false
+    useLink = config.get("Torrent", "useLink")                                          # no | hard | sym
     minSampleSize = int(config.get("Torrent", "minSampleSize"))                         # 200 (in MB)
     outputDirectory = config.get("Torrent", "outputDirectory")                          # /abs/path/to/complete/
     categories = (config.get("Torrent", "categories")).split(',')                       # music,music_videos,pictures,software

--- a/autoProcess/migratecfg.py
+++ b/autoProcess/migratecfg.py
@@ -101,6 +101,15 @@ def migrate():
         option, value = item
         if option in ["compressedExtensions", "mediaExtensions", "metaExtensions"]:
             section = "Extensions" # these were moved
+        if option == "useLink": # Sym links supported now as well.
+            try:
+                num_value = int(value)
+                if num_value == 1:
+                    value = "hard"
+                else:
+                    value = "no"
+            except ValueError:
+                pass
         confignew.set(section, option, value)
         section = "Torrent" # reset in case extensions out of order.
 

--- a/autoProcess/nzbToMediaUtil.py
+++ b/autoProcess/nzbToMediaUtil.py
@@ -150,10 +150,23 @@ def is_sample(filePath, inputName, minSampleSize):
 
 def copy_link(filePath, targetDirectory, useLink, outputDestination):
     create_destination(outputDestination)
-    if useLink != 0:
+    if useLink == "hard":
         try:
-            Logger.info("COPYLINK: Linking %s to %s", filePath, targetDirectory)
+            Logger.info("COPYLINK: Hard linking %s to %s", filePath, targetDirectory)
             linktastic.link(filePath, targetDirectory)
+        except:
+            if os.path.isfile(targetDirectory):
+                Logger.info("COPYLINK: Something went wrong in linktastic.link, but the destination file was created")
+            else:
+                Logger.info("COPYLINK: Something went wrong in linktastic.link, copying instead")
+                Logger.debug("COPYLINK: Copying %s to %s", filePath, targetDirectory)
+                shutil.copy(filePath, targetDirectory)
+    elif useLink == "sym":
+        try:
+            Logger.info("COPYLINK: Moving %s to %s before sym linking", filePath, targetDirectory)
+            shutil.move(filePath, targetDirectory)
+            Logger.info("COPYLINK: Sym linking %s to %s", targetDirectory, filePath)
+            linktastic.symlink(targetDirectory, filePath)
         except:
             if os.path.isfile(targetDirectory):
                 Logger.info("COPYLINK: Something went wrong in linktastic.link, but the destination file was created")

--- a/autoProcessMedia.cfg.sample
+++ b/autoProcessMedia.cfg.sample
@@ -79,8 +79,8 @@ web_root =
 [Torrent]
 ###### clientAgent - Supported clients: utorrent, transmission, deluge, other
 clientAgent = other
-###### useLink - Set to 1 to use or 0 depending on if you want to use hardlinks
-useLink = 1
+###### useLink - Set to hard for physical links, sym for symbolic links, and no to not use links
+useLink = hard
 ###### minSampleSize - Minimum required size to consider a file not an sample file (in MB, eg 200mb)
 minSampleSize = 200
 ###### outputDirectory - Default output directory (categories will be appended as sub directory to outputDirectory)


### PR DESCRIPTION
unRaid's file system does not support physical links, thus symbolic link support for torrents is necessary to continue seeding.
