### PR TITLE
Add niceness option to the transcoder

### DIFF
--- a/autoProcess/Transcoder.py
+++ b/autoProcess/Transcoder.py
@@ -10,6 +10,7 @@ def Transcode_directory(dirName):
     
     if os.name == 'nt':
         ffmpeg = os.path.join(os.path.dirname(sys.argv[0]), 'ffmpeg\\bin\\ffmpeg.exe') # note, will need to package in this dir.
+        useNiceness = False
         if not os.path.isfile(ffmpeg): # problem
             Logger.error("ffmpeg not found. ffmpeg needs to be located at: %s", ffmpeg) 
             Logger.info("Cannot transcode files in folder %s", dirName)
@@ -25,6 +26,7 @@ def Transcode_directory(dirName):
                 ffmpeg = 'ffmpeg'
         else:
             ffmpeg = 'ffmpeg'
+        useNiceness = True
     
     config = ConfigParser.ConfigParser()
     configFilename = os.path.join(os.path.dirname(sys.argv[0]), "autoProcessMedia.cfg")
@@ -47,6 +49,8 @@ def Transcode_directory(dirName):
     outputAudioCodec = config.get("Transcoder", "outputAudioCodec").strip()
     outputAudioBitrate = config.get("Transcoder", "outputAudioBitrate").strip()
     outputSubtitleCodec = config.get("Transcoder", "outputSubtitleCodec").strip()
+    if useNiceness:
+        niceness = int(config.get("Transcoder", "niceness"))
 
     map(lambda ext: ext.strip(), mediaContainer)
     map(lambda ext: ext.strip(), ignoreExtensions)
@@ -66,6 +70,10 @@ def Transcode_directory(dirName):
                 newfilePath = os.path.normpath(name + outputVideoExtension)
         
                 command = [ffmpeg, '-i', filePath, '-map', '0']
+
+                if useNiceness:
+                    command = ['nice', '-%d' % niceness] + command
+
                 if len(outputVideoCodec) > 0:
                     command.append('-c:v')
                     command.append(outputVideoCodec)

--- a/autoProcessMedia.cfg.sample
+++ b/autoProcessMedia.cfg.sample
@@ -103,6 +103,8 @@ metaExtensions = .nfo,.sub,.srt,.jpg,.gif
 transcode = 0
 ###### duplicate =1 will cretae a new file. =0 will replace the original
 duplicate = 1
+# Only works on Linux. Highest priority is -20, lowest priority is 19.
+niceness = 0
 ignoreExtensions = .avi,.mkv
 outputVideoExtension = .mp4
 outputVideoCodec = libx264


### PR DESCRIPTION
This patch adds a niceness option to the transcoder. It only works on Linux.

It adds the 'niceness' value to the [transcoder] configuration block. This affects process niceness in Linux.
