### PR TITLE
Default SickBeard doesn't have a parameter "process"

### DIFF
--- a/autoProcess/nzbToMediaEnv.py
+++ b/autoProcess/nzbToMediaEnv.py
@@ -14,7 +14,7 @@ fork_failed = "failed"
 fork_failed_torrent = "failed-torrent"
 
 forks = {}
-forks[fork_default] = {"dir": None, "process": None}
+forks[fork_default] = {"dir": None}
 forks[fork_failed] = {"dir": None, "failed": None}
 forks[fork_failed_torrent] = {"dir": None, "failed": None, "process_method": None}
 


### PR DESCRIPTION
This non-exsiting parameter results in a 404 Error when calling default SickBeard. And it's value is None all the time anyways.
