### PR TITLE
Specify Python version to use

### DIFF
--- a/DeleteSamples.py
+++ b/DeleteSamples.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/ResetDateTime.py
+++ b/ResetDateTime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/TorrentToMedia.py
+++ b/TorrentToMedia.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import datetime
 import os
 import time

--- a/nzbToCouchPotato.py
+++ b/nzbToCouchPotato.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/nzbToGamez.py
+++ b/nzbToGamez.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/nzbToHeadPhones.py
+++ b/nzbToHeadPhones.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/nzbToMedia.py
+++ b/nzbToMedia.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/nzbToMylar.py
+++ b/nzbToMylar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/nzbToNzbDrone.py
+++ b/nzbToNzbDrone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###

--- a/nzbToSickBeard.py
+++ b/nzbToSickBeard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 ##############################################################################
 ### NZBGET POST-PROCESSING SCRIPT                                          ###


### PR DESCRIPTION
Many Linux OSes are starting to use Python 3 as the default Python version. This PR specifies Python 2 to be used instead.
