### PR TITLE
Fix for openssl issue in requests on Debian and possibly related systems...

### DIFF
--- a/libs/requests/packages/urllib3/contrib/pyopenssl.py
+++ b/libs/requests/packages/urllib3/contrib/pyopenssl.py
@@ -56,11 +56,22 @@ __all__ = ['inject_into_urllib3', 'extract_from_urllib3']
 HAS_SNI = SUBJ_ALT_NAME_SUPPORT
 
 # Map from urllib3 to PyOpenSSL compatible parameter-values.
-_openssl_versions = {
-    ssl.PROTOCOL_SSLv23: OpenSSL.SSL.SSLv23_METHOD,
-    ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
-    ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
-}
+
+try:
+    _openssl_versions = {
+        ssl.PROTOCOL_SSLv23: OpenSSL.SSL.SSLv23_METHOD,
+        ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
+        ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
+    }
+
+except AttributeError:
+
+    _openssl_versions = {
+        ssl.PROTOCOL_SSLv23: OpenSSL.SSL.SSLv23_METHOD,
+        ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
+    }
+
+
 _openssl_verify = {
     ssl.CERT_NONE: OpenSSL.SSL.VERIFY_NONE,
     ssl.CERT_OPTIONAL: OpenSSL.SSL.VERIFY_PEER,


### PR DESCRIPTION
Removes ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD if not found to be supported on the system. 
