### PR TITLE
Add flags to make windows linking and extraction invisible

### DIFF
--- a/nzbtomedia/extractor/bin/invisible.cmd
+++ b/nzbtomedia/extractor/bin/invisible.cmd
@@ -1,1 +1,1 @@
-start /wait wscript "%~dp0\invisible.vbs" %*
+start /B /wait wscript "%~dp0\invisible.vbs" %*

--- a/nzbtomedia/extractor/extractor.py
+++ b/nzbtomedia/extractor/extractor.py
@@ -97,13 +97,17 @@ def extract(filePath, outputDestination):
     pwd = os.getcwd()  # Get our Present Working Directory
     os.chdir(outputDestination)  # Not all unpack commands accept full paths, so just extract into this directory
     devnull = open(os.devnull, 'w')
+    
+    info = subprocess.STARTUPINFO()
+    info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    
     try:  # now works same for nt and *nix
         cmd.append(filePath)  # add filePath to final cmd arg.
         if platform.system() != 'Windows':
             cmd = nzbtomedia.NICENESS + cmd
         cmd2 = cmd
         cmd2.append("-p-")  # don't prompt for password.
-        p = Popen(cmd2, stdout=devnull, stderr=devnull)  # should extract files fine.
+        p = Popen(cmd2, stdout=devnull, stderr=devnull, startupinfo=info)  # should extract files fine.
         res = p.wait()
         if (res >= 0 and os.name == 'nt') or res == 0:  # for windows chp returns process id if successful or -1*Error code. Linux returns 0 for successful.
             nzbtomedia.logger.info("EXTRACTOR: Extraction was successful for %s to %s" % (filePath, outputDestination))
@@ -117,7 +121,7 @@ def extract(filePath, outputDestination):
                 #append password here.
                 passcmd = "-p" + password
                 cmd2.append(passcmd)
-                p = Popen(cmd2, stdout=devnull, stderr=devnull)  # should extract files fine.
+                p = Popen(cmd2, stdout=devnull, stderr=devnull, startupinfo=info)  # should extract files fine.
                 res = p.wait()
                 if (res >= 0 and platform == 'Windows') or res == 0:
                     nzbtomedia.logger.info("EXTRACTOR: Extraction was successful for %s to %s using password: %s" % (

--- a/nzbtomedia/linktastic/linktastic.py
+++ b/nzbtomedia/linktastic/linktastic.py
@@ -25,6 +25,8 @@ import subprocess
 from subprocess import CalledProcessError
 import os
 
+info = subprocess.STARTUPINFO()
+info.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
 # Prevent spaces from messing with us!
 def _escape_param(param):
@@ -36,7 +38,7 @@ def _link_windows(src, dest):
     try:
         subprocess.check_output(
             'cmd /C mklink /H %s %s' % (_escape_param(dest), _escape_param(src)),
-            stderr=subprocess.STDOUT)
+            stderr=subprocess.STDOUT, startupinfo=info)
     except CalledProcessError as err:
 
         raise IOError(err.output.decode('utf-8'))
@@ -50,7 +52,7 @@ def _symlink_windows(src, dest):
     try:
         subprocess.check_output(
             'cmd /C mklink %s %s' % (_escape_param(dest), _escape_param(src)),
-            stderr=subprocess.STDOUT)
+            stderr=subprocess.STDOUT, startupinfo=info)
     except CalledProcessError as err:
         raise IOError(err.output.decode('utf-8'))
 
@@ -62,7 +64,7 @@ def _dirlink_windows(src, dest):
     try:
         subprocess.check_output(
             'cmd /C mklink /J %s %s' % (_escape_param(dest), _escape_param(src)),
-            stderr=subprocess.STDOUT)
+            stderr=subprocess.STDOUT, startupinfo=info)
     except CalledProcessError as err:
         raise IOError(err.output.decode('utf-8'))
 
@@ -74,7 +76,7 @@ def _junctionlink_windows(src, dest):
     try:
         subprocess.check_output(
             'cmd /C mklink /D %s %s' % (_escape_param(dest), _escape_param(src)),
-            stderr=subprocess.STDOUT)
+            stderr=subprocess.STDOUT, startupinfo=info)
     except CalledProcessError as err:
         raise IOError(err.output.decode('utf-8'))
 


### PR DESCRIPTION
Tested this and it should finally make all the Windows linking and extraction stuff completely invisible.