### PR TITLE
Added import subprocess as is needed to set the STARTUPINFO for Windows

### DIFF
--- a/nzbtomedia/extractor/extractor.py
+++ b/nzbtomedia/extractor/extractor.py
@@ -5,6 +5,7 @@ import stat
 from time import sleep
 import nzbtomedia
 from subprocess import call, Popen
+import subprocess
 
 def extract(filePath, outputDestination):
     success = 0


### PR DESCRIPTION
Noticed that the Windows extraction process was failing.

Turns out it was throwing an exception because the STARTUPINFO could not be set without subprocess being imported.  I left the Popen and call imports as they are since removing it would require replacing all Popen with subprocess.Popen.  Don't think this should affect *nix users.