### PR TITLE
update links to new SickRage repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Failed download handling is now provided for SABnzbd, by CouchPotatoServer; howe
 
 Failed download handling for SickBeard is available by using Tolstyak's fork [SickBeard-failed](https://github.com/hugepants/Sick-Beard)).
 To use this feature, in autoProcessTV.cfg set the parameter "fork=failed". Default is "fork=default" and will work with the standard version of SickBeard and just ignores failed downloads.
-Development of Tolstyak's fork ended in 2013, but newer forks exist with significant feature updates such as [Mr-Orange TPB](https://github.com/coach0742/Sick-Beard) (discontinued) and [SickRage](https://github.com/SiCKRAGETV/SickRage) (active). See [SickBeard Forks](https://github.com/clinton-hall/nzbToMedia/wiki/Failed-Download-Handling-%28FDH%29#sick-beard-and-its-forks "SickBeard Forks") for a list of known forks.
+Development of Tolstyak's fork ended in 2013, but newer forks exist with significant feature updates such as [Mr-Orange TPB](https://github.com/coach0742/Sick-Beard) (discontinued) and [SickRage](https://github.com/SickRage/SickRage) (active). See [SickBeard Forks](https://github.com/clinton-hall/nzbToMedia/wiki/Failed-Download-Handling-%28FDH%29#sick-beard-and-its-forks "SickBeard Forks") for a list of known forks.
 
-Full support is provided for [SickRage](https://github.com/SiCKRAGETV/SickRage). 
+Full support is provided for [SickRage](https://github.com/SickRage/SickRage). 
 
 Torrent support has been added with the assistance of jkaberg and berkona. Currently supports uTorrent, Transmission, Deluge and possibly more.
 To enable Torrent extraction, on Windows, you need to install [7-zip](http://www.7-zip.org/ "7-zip") or on *nix you need to install the following packages/commands.


### PR DESCRIPTION
The primary and most active development of SickRage has moved to a new repo