### PR TITLE
Update nzbToMediaUtil.py

### DIFF
--- a/core/nzbToMediaUtil.py
+++ b/core/nzbToMediaUtil.py
@@ -22,6 +22,8 @@ from core.utorrent.client import UTorrentClient
 from core.transmissionrpc.client import Client as TransmissionClient
 from core import logger, nzbToMediaDB
 
+requests.packages.urllib3.disable_warnings()
+
 def reportNzb(failure_link, clientAgent):
     # Contact indexer site
     logger.info("Sending failure notification to indexer site")
@@ -1094,9 +1096,9 @@ def plex_update(category):
     if core.FAILED:
         return
     if core.PLEXSSL:
-        url = 'https://'
+        url = "https://"
     else:
-        url = 'http://'
+        url = "http://"
     url = url + core.PLEXHOST + ':' + core.PLEXPORT + '/library/sections/'
     section = None
     if not core.PLEXSEC:


### PR DESCRIPTION
Seems to be a fix for:

Traceback (most recent call last):
  File "/opt/sickrage/contrib/nzbToMedia/nzbToSickBeard.py", line 252, in <module>
    result = nzbToMedia.main(sys.argv, section)
  File "/opt/sickrage/contrib/nzbToMedia/nzbToMedia.py", line 712, in main
    download_id='')
  File "/opt/sickrage/contrib/nzbToMedia/nzbToMedia.py", line 611, in process
    plex_update(inputCategory)
  File "/opt/sickrage/contrib/nzbToMedia/core/nzbToMediaUtil.py", line 1063, in plex_update
    url = url + core.PLEXHOST + ':' + core.PLEXPORT + '/library/sections/'
UnboundLocalError: local variable 'url' referenced before assignment
Exception TypeError: "'NoneType' object is not callable" in <bound method PosixProcess.__del__ of <core.nzbToMediaUtil.PosixProcess instance at 0x7f3d911098c0>> ignored

Also fixing remnants of this issue:

https://github.com/clinton-hall/nzbToMedia/issues/804