### PR TITLE
Report Downloader failures to SickRage

### DIFF
--- a/core/autoProcess/autoProcessTV.py
+++ b/core/autoProcess/autoProcessTV.py
@@ -176,9 +176,15 @@ class autoProcessTV:
             logger.warning("No media files found in directory %s to manually process." % (dirName), section)
             return [0, ""]   # Success (as far as this script is concerned)
         elif nzbExtractionBy == "Destination":
-            logger.info("Check for media files ignored because nzbExtractionBy is set to Destination. Setting status Success.")
-            status = 0
-            failed = 0
+            logger.info("Check for media files ignored because nzbExtractionBy is set to Destination.")
+            if failed == 0:
+                logger.info("Setting Status Success.")
+                status = 0
+                failed = 0
+            else:
+               logger.info("Downloader reported an error during download or verification. Processing this as a failed download.")
+               status = 1
+               failed = 1
         else:
             logger.warning("No media files found in directory %s. Processing this as a failed download" % (dirName), section)
             status = 1

--- a/core/autoProcess/autoProcessTV.py
+++ b/core/autoProcess/autoProcessTV.py
@@ -177,7 +177,7 @@ class autoProcessTV:
             return [0, ""]   # Success (as far as this script is concerned)
         elif nzbExtractionBy == "Destination":
             logger.info("Check for media files ignored because nzbExtractionBy is set to Destination.")
-            if failed == 0:
+            if failed == "0":
                 logger.info("Setting Status Success.")
                 status = 0
                 failed = 0


### PR DESCRIPTION
When extraction is done by SickRage, report failures from Downloader to SickRage.
For example, when download fails in SAB because out of retention SAB reports failed status -1. Or when verification fails SAB reports failed status 1. In such cases also report failure to SickRage. Without this fix, this results in "Returned log from SickBeard was not as expected.!" and SickRage keeping Snatched status.