### PR TITLE
Strip trailing and leading whitespaces from `mount_points`

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -366,6 +366,7 @@ def initialize(section=None):
     if REMOTEPATHS:
         if isinstance(REMOTEPATHS, list): REMOTEPATHS = ','.join(REMOTEPATHS)  # fix in case this imported as list.
         REMOTEPATHS = [ tuple(item.split(',')) for item in REMOTEPATHS.split('|') ]  # /volume1/Public/,E:\|/volume2/share/,\\NAS\
+        REMOTEPATHS = [ (local.strip(), remote.strip()) for local, remote in REMOTEPATHS ] # strip trailing and leading whitespaces
 
     PLEXSSL = int(CFG["Plex"]["plex_ssl"])
     PLEXHOST = CFG["Plex"]["plex_host"]


### PR DESCRIPTION
So we can define mount_points like this:

```
/local_path/a, /remote_path/a | /local_path/b, /remote_path/b | /local_path/c, /remote_path/c
```