### PR TITLE
Sort listMediaFiles results by path length

### DIFF
--- a/core/nzbToMediaUtil.py
+++ b/core/nzbToMediaUtil.py
@@ -977,7 +977,7 @@ def listMediaFiles(path, minSize=0, delete_ignored=0, media=True, audio=True, me
 
             files.append(fullCurFile)
 
-    return files
+    return sorted(files,key=len)
 
 def find_imdbid(dirName, inputName):
     imdbid = None


### PR DESCRIPTION
Sort listMediaFiles results by path length in order to give priority to files higher in the folder hierarchy.  Corrects an error where the contents of an archive file in a child directory could overwrite other archive files in the parent directory before the overwritten archive has been extracted.