### PR TITLE
Do not remove codec/release_group information from base folder

### DIFF
--- a/TorrentToMedia.py
+++ b/TorrentToMedia.py
@@ -112,7 +112,9 @@ def processTorrent(inputDirectory, inputName, inputCategory, inputHash, inputID,
     # Incase input is not directory, make sure to create one.
     # This way Processing is isolated.
     if not os.path.isdir(os.path.join(inputDirectory, inputName)):
-        basename = os.path.splitext(core.sanitizeName(inputName))[0]
+        basename = os.path.basename(inputDirectory)
+        basename = core.sanitizeName(inputName) \
+            if inputName == basename else os.path.splitext(core.sanitizeName(inputName)[0])
         outputDestination = os.path.join(core.OUTPUTDIRECTORY, inputCategory, basename)
     elif uniquePath:
         outputDestination = os.path.normpath(


### PR DESCRIPTION
The special handling for single file torrents introduced by this commit https://github.com/clinton-hall/nzbToMedia/commit/96dfe7d765a1f87e7d90523ee4647c1fb73a7d4f removes important information when the torrent is not a single file.

Given the following torrent: `How.To.Be.Single.2016.1080p.BluRay.x264-BLOW/blow-how.to.be.single.2016.1080p.bluray.x264.mkv`
and the following output example:

```
2016-05-14 23:28:59 DEBUG   ::MAIN: Options passed into TorrentToMedia: ['/scripts/nzbToMedia/TorrentToMedia.py', 'e64e627da6176ca1433af720a7f2fd37c0ad0aba', 'How.To.Be.Single.2016.1080p.BluRay.x264-BLOW', '/downloads/movies']
2016-05-14 23:28:59 DEBUG   ::MAIN: Adding TORRENT download info for directory /downloads/movies to database
2016-05-14 23:28:59 DEBUG   ::MAIN: Received Directory: /downloads/movies | Name: How.To.Be.Single.2016.1080p.BluRay.x264-BLOW | Category: movies
2016-05-14 23:28:59 DEBUG   ::MAIN: SEARCH: Found the Category: movies in directory structure
2016-05-14 23:28:59 INFO    ::MAIN: SEARCH: Found torrent directory How.To.Be.Single.2016.1080p.BluRay.x264-BLOW in input directory directory /downloads/movies
2016-05-14 23:28:59 INFO    ::MAIN: SEARCH: Setting inputDirectory to /downloads/movies/How.To.Be.Single.2016.1080p.BluRay.x264-BLOW
2016-05-14 23:28:59 DEBUG   ::MAIN: Determined Directory: /downloads/movies/How.To.Be.Single.2016.1080p.BluRay.x264-BLOW | Name: How.To.Be.Single.2016.1080p.BluRay.x264-BLOW | Category: movies
2016-05-14 23:28:59 INFO    ::MAIN: Auto-detected SECTION:CouchPotato
2016-05-14 23:28:59 DEBUG   ::MAIN: Stopping torrent How.To.Be.Single.2016.1080p.BluRay.x264-BLOW in deluge while processing
2016-05-14 23:29:04 INFO    ::MAIN: Output directory set to: /downloads/processing/movies/How.To.Be.Single.2016.1080p.BluRay
2016-05-14 23:29:04 DEBUG   ::MAIN: Scanning files in directory: /downloads/movies/How.To.Be.Single.2016.1080p.BluRay.x264-BLOW
```

Note 
```
Determined Directory: /downloads/movies/How.To.Be.Single.2016.1080p.BluRay.x264-BLOW | Name: How.To.Be.Single.2016.1080p.BluRay.x264-BLOW
```
and
```
Output directory set to: /downloads/processing/movies/How.To.Be.Single.2016.1080p.BluRay
```

The resulting output directory doesn't have the suffix `.x264-BLOW` as it should be.


Removing this information might confuses `guessit` when parsing the release name. The guessed `title` and `release_group` could get completely wrong.


```
# Latest nzbToMedia version
$> guessit "How.To.Be.Single.2016.1080p.BluRay/blow-how.to.be.single.2016.1080p.bluray.x264.mkv"
For: How.To.Be.Single.2016.1080p.BluRay/blow-how.to.be.single.2016.1080p.bluray.x264.mkv
GuessIt found: {
    "year": 2016, 
    "screen_size": "1080p", 
    "format": "BluRay", 
    "title": "blow-how to be single", 
    "video_codec": "h264", 
    "container": "mkv", 
    "mimetype": "video/x-matroska", 
    "type": "movie"
}
```

```
# With proposed fix
$> guessit "How.To.Be.Single.2016.1080p.BluRay.x264-BLOW/blow-how.to.be.single.2016.1080p.bluray.x264.mkv"
For: How.To.Be.Single.2016.1080p.BluRay.x264-BLOW/blow-how.to.be.single.2016.1080p.bluray.x264.mkv
GuessIt found: {
    "title": "How To Be Single", 
    "year": 2016, 
    "screen_size": "1080p", 
    "format": "BluRay", 
    "video_codec": "h264", 
    "release_group": "BLOW", 
    "container": "mkv", 
    "mimetype": "video/x-matroska", 
    "type": "movie"
}
```

The proposed fix:
The `inputDirectory` basename and `inputName` are always the same for normal torrents (non single file torrents), they only differ for single-file torrents, so the extension is stripped out only for this case.