### PR TITLE
Bug fix

### DIFF
--- a/core/autoProcess/autoProcessComics.py
+++ b/core/autoProcess/autoProcessComics.py
@@ -16,13 +16,15 @@ class autoProcessComics(object):
             logger.warning("FAILED DOWNLOAD DETECTED, nothing to process.", section)
             return [1, "{0}: Failed to post-process. {1} does not support failed downloads".format(section, section)]
 
-        host = core.CFG[section][inputCategory]["host"]
-        port = core.CFG[section][inputCategory]["port"]
-        username = core.CFG[section][inputCategory]["username"]
-        password = core.CFG[section][inputCategory]["password"]
-        ssl = int(core.CFG[section][inputCategory].get("ssl", 0))
-        web_root = core.CFG[section][inputCategory].get("web_root", "")
-        remote_path = int(core.CFG[section][inputCategory].get("remote_path"), 0)
+        cfg = dict(core.CFG[section][inputCategory])
+
+        host = cfg["host"]
+        port = cfg["port"]
+        username = cfg["username"]
+        password = cfg["password"]
+        ssl = int(cfg.get("ssl", 0))
+        web_root = cfg.get("web_root", "")
+        remote_path = int(cfg.get("remote_path"), 0)
         protocol = "https://" if ssl else "http://"
 
         url = "{0}{1}:{2}{3}/post_process".format(protocol, host, port, web_root)

--- a/core/autoProcess/autoProcessGames.py
+++ b/core/autoProcess/autoProcessGames.py
@@ -15,12 +15,14 @@ class autoProcessGames(object):
     def process(self, section, dirName, inputName=None, status=0, clientAgent='manual', inputCategory=None):
         status = int(status)
 
-        host = core.CFG[section][inputCategory]["host"]
-        port = core.CFG[section][inputCategory]["port"]
-        apikey = core.CFG[section][inputCategory]["apikey"]
-        library = core.CFG[section][inputCategory].get("library")
-        ssl = int(core.CFG[section][inputCategory].get("ssl", 0))
-        web_root = core.CFG[section][inputCategory].get("web_root", "")
+        cfg = dict(core.CFG[section][inputCategory])
+
+        host = cfg["host"]
+        port = cfg["port"]
+        apikey = cfg["apikey"]
+        library = cfg.get("library")
+        ssl = int(cfg.get("ssl", 0))
+        web_root = cfg.get("web_root", "")
         protocol = "https://" if ssl else "http://"
 
         url = "{0}{1}:{2}{3}/api".format(protocol, host, port, web_root)

--- a/core/autoProcess/autoProcessMovie.py
+++ b/core/autoProcess/autoProcessMovie.py
@@ -105,16 +105,18 @@ class autoProcessMovie(object):
 
     def process(self, section, dirName, inputName=None, status=0, clientAgent="manual", download_id="", inputCategory=None, failureLink=None):
 
-        host = core.CFG[section][inputCategory]["host"]
-        port = core.CFG[section][inputCategory]["port"]
-        apikey = core.CFG[section][inputCategory]["apikey"]
-        method = core.CFG[section][inputCategory]["method"]
-        delete_failed = int(core.CFG[section][inputCategory]["delete_failed"])
-        wait_for = int(core.CFG[section][inputCategory]["wait_for"])
-        ssl = int(core.CFG[section][inputCategory].get("ssl", 0))
-        web_root = core.CFG[section][inputCategory].get("web_root", "")
-        remote_path = int(core.CFG[section][inputCategory].get("remote_path", 0))
-        extract = int(core.CFG[section][inputCategory].get("extract", 0))
+        cfg = dict(core.CFG[section][inputCategory])
+
+        host = cfg["host"]
+        port = cfg["port"]
+        apikey = cfg["apikey"]
+        method = cfg["method"]
+        delete_failed = int(cfg["delete_failed"])
+        wait_for = int(cfg["wait_for"])
+        ssl = int(cfg.get("ssl", 0))
+        web_root = cfg.get("web_root", "")
+        remote_path = int(cfg.get("remote_path", 0))
+        extract = int(cfg.get("extract", 0))
         protocol = "https://" if ssl else "http://"
 
         baseURL = "{0}{1}:{2}{3}/api/{4}".format(protocol, host, port, web_root, apikey)

--- a/core/autoProcess/autoProcessMovie.py
+++ b/core/autoProcess/autoProcessMovie.py
@@ -114,7 +114,7 @@ class autoProcessMovie(object):
         ssl = int(core.CFG[section][inputCategory].get("ssl", 0))
         web_root = core.CFG[section][inputCategory].get("web_root", "")
         remote_path = int(core.CFG[section][inputCategory].get("remote_path", 0))
-        extract = int(section[inputCategory].get("extract", 0))
+        extract = int(core.CFG[section][inputCategory].get("extract", 0))
         protocol = "https://" if ssl else "http://"
 
         baseURL = "{0}{1}:{2}{3}/api/{4}".format(protocol, host, port, web_root, apikey)

--- a/core/autoProcess/autoProcessMusic.py
+++ b/core/autoProcess/autoProcessMusic.py
@@ -42,14 +42,16 @@ class autoProcessMusic(object):
     def process(self, section, dirName, inputName=None, status=0, clientAgent="manual", inputCategory=None):
         status = int(status)
 
-        host = core.CFG[section][inputCategory]["host"]
-        port = core.CFG[section][inputCategory]["port"]
-        apikey = core.CFG[section][inputCategory]["apikey"]
-        wait_for = int(core.CFG[section][inputCategory]["wait_for"])
-        ssl = int(core.CFG[section][inputCategory].get("ssl", 0))
-        web_root = core.CFG[section][inputCategory].get("web_root", "")
-        remote_path = int(core.CFG[section][inputCategory].get("remote_path", 0))
-        extract = int(core.CFG[section][inputCategory].get("extract", 0))
+        cfg = dict(core.CFG[section][inputCategory])
+
+        host = cfg["host"]
+        port = cfg["port"]
+        apikey = cfg["apikey"]
+        wait_for = int(cfg["wait_for"])
+        ssl = int(cfg.get("ssl", 0))
+        web_root = cfg.get("web_root", "")
+        remote_path = int(cfg.get("remote_path", 0))
+        extract = int(cfg.get("extract", 0))
         protocol = "https://" if ssl else "http://"
 
         url = "{0}{1}:{2}{3}/api".format(protocol, host, port, web_root)

--- a/core/autoProcess/autoProcessMusic.py
+++ b/core/autoProcess/autoProcessMusic.py
@@ -49,7 +49,7 @@ class autoProcessMusic(object):
         ssl = int(core.CFG[section][inputCategory].get("ssl", 0))
         web_root = core.CFG[section][inputCategory].get("web_root", "")
         remote_path = int(core.CFG[section][inputCategory].get("remote_path", 0))
-        extract = int(section[inputCategory].get("extract", 0))
+        extract = int(core.CFG[section][inputCategory].get("extract", 0))
         protocol = "https://" if ssl else "http://"
 
         url = "{0}{1}:{2}{3}/api".format(protocol, host, port, web_root)

--- a/core/autoProcess/autoProcessTV.py
+++ b/core/autoProcess/autoProcessTV.py
@@ -52,10 +52,13 @@ class autoProcessTV(object):
                 return False
 
     def processEpisode(self, section, dirName, inputName=None, failed=False, clientAgent="manual", download_id=None, inputCategory=None, failureLink=None):
-        host = core.CFG[section][inputCategory]["host"]
-        port = core.CFG[section][inputCategory]["port"]
-        ssl = int(core.CFG[section][inputCategory].get("ssl", 0))
-        web_root = core.CFG[section][inputCategory].get("web_root", "")
+
+        cfg = dict(core.CFG[section][inputCategory])
+
+        host = cfg["host"]
+        port = cfg["port"]
+        ssl = int(cfg.get("ssl", 0))
+        web_root = cfg.get("web_root", "")
         protocol = "https://" if ssl else "http://"
 
         if not server_responding("{0}{1}:{2}{3}".format(protocol, host, port, web_root)):
@@ -65,17 +68,17 @@ class autoProcessTV(object):
         # auto-detect correct fork
         fork, fork_params = autoFork(section, inputCategory)
 
-        username = core.CFG[section][inputCategory].get("username", "")
-        password = core.CFG[section][inputCategory].get("password", "")
-        apikey = core.CFG[section][inputCategory].get("apikey", "")
-        delete_failed = int(core.CFG[section][inputCategory].get("delete_failed", 0))
-        nzbExtractionBy = core.CFG[section][inputCategory].get("nzbExtractionBy", "Downloader")
-        process_method = core.CFG[section][inputCategory].get("process_method")
-        remote_path = int(core.CFG[section][inputCategory].get("remote_path", 0))
-        wait_for = int(core.CFG[section][inputCategory].get("wait_for", 2))
-        force = int(core.CFG[section][inputCategory].get("force", 0))
-        delete_on = int(core.CFG[section][inputCategory].get("delete_on", 0))
-        extract = int(core.CFG[section][inputCategory].get("extract", 0))
+        username = cfg.get("username", "")
+        password = cfg.get("password", "")
+        apikey = cfg.get("apikey", "")
+        delete_failed = int(cfg.get("delete_failed", 0))
+        nzbExtractionBy = cfg.get("nzbExtractionBy", "Downloader")
+        process_method = cfg.get("process_method")
+        remote_path = int(cfg.get("remote_path", 0))
+        wait_for = int(cfg.get("wait_for", 2))
+        force = int(cfg.get("force", 0))
+        delete_on = int(cfg.get("delete_on", 0))
+        extract = int(cfg.get("extract", 0))
 
         if not os.path.isdir(dirName) and os.path.isfile(dirName):  # If the input directory is a file, assume single file download and split dir/name.
             dirName = os.path.split(os.path.normpath(dirName))[0]

--- a/core/autoProcess/autoProcessTV.py
+++ b/core/autoProcess/autoProcessTV.py
@@ -75,7 +75,7 @@ class autoProcessTV(object):
         wait_for = int(core.CFG[section][inputCategory].get("wait_for", 2))
         force = int(core.CFG[section][inputCategory].get("force", 0))
         delete_on = int(core.CFG[section][inputCategory].get("delete_on", 0))
-        extract = int(section[inputCategory].get("extract", 0))
+        extract = int(core.CFG[section][inputCategory].get("extract", 0))
 
         if not os.path.isdir(dirName) and os.path.isfile(dirName):  # If the input directory is a file, assume single file download and split dir/name.
             dirName = os.path.split(os.path.normpath(dirName))[0]


### PR DESCRIPTION
* Fix config option `extract` never being used.
The broad except clauses that were used before masked the fact that the `extract` was never used, as it was attempting to get the value from the `section` string instead of the config.

* Fix `TypeError` for missing keys by type-casting config to dict
Using `get` to get values raises a `TypeError` if they key does not exist, preventing the default from being used.  This type-casts the config to a dict so the config follows expected dict behaviour.