### PR TITLE
TorrentToMedia: fix invalid indexing scope, select first el. of pair not char

### DIFF
--- a/TorrentToMedia.py
+++ b/TorrentToMedia.py
@@ -114,7 +114,7 @@ def processTorrent(inputDirectory, inputName, inputCategory, inputHash, inputID,
     if not os.path.isdir(os.path.join(inputDirectory, inputName)):
         basename = os.path.basename(inputDirectory)
         basename = core.sanitizeName(inputName) \
-            if inputName == basename else os.path.splitext(core.sanitizeName(inputName)[0])
+            if inputName == basename else os.path.splitext(core.sanitizeName(inputName))[0]
         outputDestination = os.path.join(core.OUTPUTDIRECTORY, inputCategory, basename)
     elif uniquePath:
         outputDestination = os.path.normpath(


### PR DESCRIPTION
Fix for issue manifesting itself with the following exception:

    Traceback (most recent call last):
      File "/opt/nzbToMedia/TorrentToMedia.py", line 366, in <module>
        exit(main(sys.argv))
      File "/opt/nzbToMedia/TorrentToMedia.py", line 303, in main
        result = processTorrent(inputDirectory, inputName, inputCategory, inputHash, inputID, clientAgent)
      File "/opt/nzbToMedia/TorrentToMedia.py", line 118, in processTorrent
        outputDestination = os.path.join(core.OUTPUTDIRECTORY, inputCategory, basename)  File "/usr/local/lib/python2.7/posixpath.py", line 68, in join
        if b.startswith('/'):
    AttributeError: 'tuple' object has no attribute 'startswith'

The indexing operator was applied to wrong object: should be selecting first
element of tuple returned by splitext() instead of first char of string passed
to splitext.