### PR TITLE
Add Medusa fork and new param "ignore_subs"

### DIFF
--- a/autoProcessMedia.cfg.spec
+++ b/autoProcessMedia.cfg.spec
@@ -85,8 +85,10 @@
         process_method =
         # force processing of already processed content when running a manual scan.
         force = 0
-        # tell SickRage to delete all source files after processing.
+        # tell SickRage/Medusa to delete all source files after processing.
         delete_on = 0
+        # tell Medusa to ignore check for associated subtitle check when postponing release
+        ignore_subs = 0
         extract = 1
         nzbExtractionBy = Downloader
         # Set this to minimum required size to consider a media file valid (in MB)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -63,15 +63,17 @@ FORK_FAILED = "failed"
 FORK_FAILED_TORRENT = "failed-torrent"
 FORK_SICKRAGETV = "sickragetv"
 FORK_SICKRAGE = "sickrage"
+FORK_MEDUSA = "medusa"
 FORK_SICKGEAR = "sickgear"
 FORKS[FORK_DEFAULT] = {"dir": None}
 FORKS[FORK_FAILED] = {"dirName": None, "failed": None}
 FORKS[FORK_FAILED_TORRENT] = {"dir": None, "failed": None, "process_method": None}
 FORKS[FORK_SICKRAGETV] = {"proc_dir": None, "failed": None, "process_method": None, "force": None, "delete_on": None}
 FORKS[FORK_SICKRAGE] = {"proc_dir": None, "failed": None, "process_method": None, "force": None, "delete_on": None}
+FORKS[FORK_MEDUSA] = {"proc_dir": None, "failed": None, "process_method": None, "force": None, "delete_on": None, "ignore_subs":None}
 FORKS[FORK_SICKGEAR] = {"dir": None, "failed": None, "process_method": None, "force": None}
 ALL_FORKS = {"dir": None, "dirName": None, "proc_dir": None, "failed": None, "process_method": None, "force": None,
-             "delete_on": None}
+             "delete_on": None, "ignore_subs": None}
 
 # NZBGet Exit Codes
 NZBGET_POSTPROCESS_PARCHECK = 92

--- a/core/autoProcess/autoProcessTV.py
+++ b/core/autoProcess/autoProcessTV.py
@@ -78,6 +78,7 @@ class autoProcessTV(object):
         wait_for = int(cfg.get("wait_for", 2))
         force = int(cfg.get("force", 0))
         delete_on = int(cfg.get("delete_on", 0))
+        ignore_subs = int(cfg.get("ignore_subs", 0))
         extract = int(cfg.get("extract", 0))
 
         if not os.path.isdir(dirName) and os.path.isfile(dirName):  # If the input directory is a file, assume single file download and split dir/name.
@@ -195,6 +196,12 @@ class autoProcessTV(object):
             if param == "delete_on":
                 if delete_on:
                     fork_params[param] = delete_on
+                else:
+                    del fork_params[param]
+
+            if param == "ignore_subs":
+                if ignore_subs:
+                    fork_params[param] = ignore_subs
                 else:
                     del fork_params[param]
 

--- a/nzbToMedia.py
+++ b/nzbToMedia.py
@@ -124,6 +124,11 @@
 # set to 1 to delete failed, or 0 to leave files in place.
 #sbdelete_failed=0
 
+# SickBeard Ignore associated subtitle check (0, 1).
+#
+# set to 1 to ignore subtitles check, or 0 to don't check.
+#sbignore_subs=0
+
 # SickBeard process method.
 #
 # set this to move, copy, hardlink, symlink as appropriate if you want to over-ride SB defaults. Leave blank to use SB default.


### PR DESCRIPTION
Medusa has a feature to only PP file when has subtitle associated.
so `FINDSUBTITLES` thread keeps searching for subs in PP folder until finds and then it calls post-processor to PP that file + subs

How it detects the fork? Will it detect Medusa in `sbfork=auto` ?

Obs: Alls devs from SickRage left - except one - and created fork Medusa

Very active fork: https://github.com/pymedusa/SickRage/commits/develop
