### PR TITLE
Add the ability to set octal permissions on the processed files prior to handing it off to Sickrage/Couchpotato

### DIFF
--- a/autoProcessMedia.cfg.spec
+++ b/autoProcessMedia.cfg.spec
@@ -64,6 +64,8 @@
         remote_path = 0
         ##### Set to path where download client places completed downloads locally for this category
         watch_dir =
+        ##### Set the recursive directory permissions to the following (0 to disable)
+        chmodDirectory = 0
 
 [SickBeard]
     #### autoProcessing for TV Series
@@ -99,6 +101,8 @@
         remote_path = 0
         ##### Set to path where download client places completed downloads locally for this category
         watch_dir =
+        ##### Set the recursive directory permissions to the following (0 to disable)
+        chmodDirectory = 0
 
 [NzbDrone]
     #### autoProcessing for TV Series

--- a/core/autoProcess/autoProcessMovie.py
+++ b/core/autoProcess/autoProcessMovie.py
@@ -195,6 +195,12 @@ class autoProcessMovie(object):
                 if result == 0:
                     logger.debug("Transcoding succeeded for files in {0}".format(dirName), section)
                     dirName = newDirName
+
+                    chmod_directory = int(cfg.get("chmodDirectory", 0), 8)
+                    logger.debug("Config setting 'chmodDirectory' currently set to {0}".format(oct(chmod_directory)), section)
+                    if chmod_directory:
+                        logger.info("Attempting to set the octal permission of '{0}' on directory '{1}'".format(oct(chmod_directory), dirName), section)
+                        core.rchmod(dirName, chmod_directory)
                 else:
                     logger.error("Transcoding failed for files in {0}".format(dirName), section)
                     return [1, "{0}: Failed to post-process - Transcoding failed".format(section)]

--- a/core/autoProcess/autoProcessTV.py
+++ b/core/autoProcess/autoProcessTV.py
@@ -163,12 +163,19 @@ class autoProcessTV(object):
             if result == 0:
                 logger.debug("SUCCESS: Transcoding succeeded for files in {0}".format(dirName), section)
                 dirName = newDirName
+
+                chmod_directory = int(cfg.get("chmodDirectory", 0), 8)
+                logger.debug("Config setting 'chmodDirectory' currently set to {0}".format(oct(chmod_directory)), section)
+                if chmod_directory:
+                    logger.info("Attempting to set the octal permission of '{0}' on directory '{1}'".format(oct(chmod_directory), dirName), section)
+                    core.rchmod(dirName, chmod_directory)
             else:
                 logger.error("FAILED: Transcoding failed for files in {0}".format(dirName), section)
                 return [1, "{0}: Failed to post-process - Transcoding failed".format(section)]
 
         # configure SB params to pass
         fork_params['quiet'] = 1
+        fork_params['proc_type'] = 'manual'
         if inputName is not None:
             fork_params['nzbName'] = inputName
 

--- a/core/transcoder/transcoder.py
+++ b/core/transcoder/transcoder.py
@@ -268,20 +268,20 @@ def buildCommands(file, newDir, movieName, bitbucket):
         if audio2:  # right language and codec...
             map_cmd.extend(['-map', '0:{index}'.format(index=audio2[0]["index"])])
             a_mapped.extend([audio2[0]["index"]])
-            bitrate = int(audio2[0].get("bit_rate", 0)) / 1000
-            channels = int(audio2[0].get("channels", 0))
+            bitrate = int(float(audio2[0].get("bit_rate", 0))) / 1000
+            channels = int(float(audio2[0].get("channels", 0)))
             audio_cmd.extend(['-c:a:{0}'.format(used_audio), 'copy'])
         elif audio1:  # right language wrong codec.
             map_cmd.extend(['-map', '0:{index}'.format(index=audio1[0]["index"])])
             a_mapped.extend([audio1[0]["index"]])
-            bitrate = int(audio1[0].get("bit_rate", 0)) / 1000
-            channels = int(audio1[0].get("channels", 0))
+            bitrate = int(float(audio1[0].get("bit_rate", 0))) / 1000
+            channels = int(float(audio1[0].get("channels", 0)))
             audio_cmd.extend(['-c:a:{0}'.format(used_audio), core.ACODEC if core.ACODEC else 'copy'])
         elif audio3:  # just pick the default audio track
             map_cmd.extend(['-map', '0:{index}'.format(index=audio3[0]["index"])])
             a_mapped.extend([audio3[0]["index"]])
-            bitrate = int(audio3[0].get("bit_rate", 0)) / 1000
-            channels = int(audio3[0].get("channels", 0))
+            bitrate = int(float(audio3[0].get("bit_rate", 0))) / 1000
+            channels = int(float(audio3[0].get("channels", 0)))
             audio_cmd.extend(['-c:a:{0}'.format(used_audio), core.ACODEC if core.ACODEC else 'copy'])
 
         if core.ACHANNELS and channels and channels > core.ACHANNELS:
@@ -305,14 +305,14 @@ def buildCommands(file, newDir, movieName, bitbucket):
             if audio4:  # right language and codec.
                 map_cmd.extend(['-map', '0:{index}'.format(index=audio4[0]["index"])])
                 a_mapped.extend([audio4[0]["index"]])
-                bitrate = int(audio4[0].get("bit_rate", 0)) / 1000
-                channels = int(audio4[0].get("channels", 0))
+                bitrate = int(float(audio4[0].get("bit_rate", 0))) / 1000
+                channels = int(float(audio4[0].get("channels", 0)))
                 audio_cmd2.extend(['-c:a:{0}'.format(used_audio), 'copy'])
             elif audio1:  # right language wrong codec.
                 map_cmd.extend(['-map', '0:{index}'.format(index=audio1[0]["index"])])
                 a_mapped.extend([audio1[0]["index"]])
-                bitrate = int(audio1[0].get("bit_rate", 0)) / 1000
-                channels = int(audio1[0].get("channels", 0))
+                bitrate = int(float(audio1[0].get("bit_rate", 0))) / 1000
+                channels = int(float(audio1[0].get("channels", 0)))
                 if core.ACODEC2:
                     audio_cmd2.extend(['-c:a:{0}'.format(used_audio), core.ACODEC2])
                 else:
@@ -320,8 +320,8 @@ def buildCommands(file, newDir, movieName, bitbucket):
             elif audio3:  # just pick the default audio track
                 map_cmd.extend(['-map', '0:{index}'.format(index=audio3[0]["index"])])
                 a_mapped.extend([audio3[0]["index"]])
-                bitrate = int(audio3[0].get("bit_rate", 0)) / 1000
-                channels = int(audio3[0].get("channels", 0))
+                bitrate = int(float(audio3[0].get("bit_rate", 0))) / 1000
+                channels = int(float(audio3[0].get("channels", 0)))
                 if core.ACODEC2:
                     audio_cmd2.extend(['-c:a:{0}'.format(used_audio), core.ACODEC2])
                 else:
@@ -350,8 +350,8 @@ def buildCommands(file, newDir, movieName, bitbucket):
                 used_audio += 1
                 map_cmd.extend(['-map', '0:{index}'.format(index=audio["index"])])
                 audio_cmd3 = []
-                bitrate = int(audio.get("bit_rate", 0)) / 1000
-                channels = int(audio.get("channels", 0))
+                bitrate = int(float(audio.get("bit_rate", 0))) / 1000
+                channels = int(float(audio.get("channels", 0)))
                 if audio["codec_name"] in core.ACODEC3_ALLOW:
                     audio_cmd3.extend(['-c:a:{0}'.format(used_audio), 'copy'])
                 else:


### PR DESCRIPTION
If set, the `chmodDirectory` option instructs the nzbToMedia post-processing script to set the recursive directory permissions to the octal value specified.

The `proc_type = manual` parameter is also needed as SickRage uses this (along with `delete_on = 0`) to trigger "Manual Post Processing" mode.

More info: https://github.com/SickRage/SickRage/blob/619a1a43b16853f533f932d72cd58b139877b150/sickbeard/processTV.py#L293

(manual post-processing mode is important in situations where you don't want SickRage to delete files it thinks are un-necessary -- eg. `.srt` files)


#### Background

I ran into an issue where the permissions on the subtitle files (downloaded via the `subliminal` library) were set to `0600`. This ended up breaking post-processing in situations where the user running sabnzbd was different than the user running sickbeard or couchpotato, since the eventual sickbeard/couchpotato `copy` could not access the downloaded `.srt` file.

I took a peek in the vendored subliminal library (in the `save_subtitles` function) and it does not appear to set the file permissions in the `io.open` call:

https://github.com/marvinpinto/nzbToMedia/blob/set-nzb-directory-permissions/libs/subliminal/core.py#L654

I also verified the umask of the user executing the nzbtomedia script (sabnzbd in my case) and it appears to be set correctly to `0002`.

This PR is also somewhat similar to what was done in https://github.com/clinton-hall/nzbToMedia/pull/837 -- which was why I chose the identically named `chmodDirectory` option.


#### Feedback

I would love your feedback on whether you feel like this is the correct way to go about solving this, and as always, thank you for your awesome work here :smile: 

Also, I came across the 2c8b2fc8cf5fed3102ebc64f440fbce927209ea0 issue when looking into this PR. I can gladly move it to another PR or remove it altogether if you wish.