### PR TITLE
Check for existence of codec_type key when counting streams

### DIFF
--- a/core/transcoder/transcoder.py
+++ b/core/transcoder/transcoder.py
@@ -26,8 +26,8 @@ def isVideoGood(videofile, status):
             disable = True
             logger.info("DISABLED: ffprobe failed to analyse test file. Stopping corruption check.", 'TRANSCODER')
         if test_details.get("streams"):
-            vidStreams = [item for item in test_details["streams"] if item["codec_type"] == "video"]
-            audStreams = [item for item in test_details["streams"] if item["codec_type"] == "audio"]
+            vidStreams = [item for item in test_details["streams"] if "codec_type" in item and item["codec_type"] == "video"]
+            audStreams = [item for item in test_details["streams"] if "codec_type" in item and item["codec_type"] == "audio"]
             if not (len(vidStreams) > 0 and len(audStreams) > 0):
                 disable = True
                 logger.info("DISABLED: ffprobe failed to analyse streams from test file. Stopping corruption check.",


### PR DESCRIPTION
It seems like there can be streams with no associated type, which leads to a crash.

```
{
            "index": 2,
            "codec_tag_string": "[0][0][0][0]",
            "codec_tag": "0x0000",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "127501/25",
            "start_pts": 0,
            "start_time": "0.000000",
            "duration_ts": 1,
            "duration": "5100.040000",
            "nb_frames": "1",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0
            },
            "tags": {
                "title": "..."
            }
}
```