### PR TITLE
Increase shutil copy buffer length to improve network performance

### DIFF
--- a/core/nzbToMediaUtil.py
+++ b/core/nzbToMediaUtil.py
@@ -27,6 +27,11 @@ from core import logger, nzbToMediaDB
 
 requests.packages.urllib3.disable_warnings()
 
+# Monkey Patch shutil.copyfileobj() to adjust the buffer length to 512KB rather than 4KB
+shutil.copyfileobjOrig = shutil.copyfileobj
+def copyfileobjFast(fsrc, fdst, length=512*1024):
+    shutil.copyfileobjOrig(fsrc, fdst, length=length)
+shutil.copyfileobj = copyfileobjFast
 
 def reportNzb(failure_link, clientAgent):
     # Contact indexer site


### PR DESCRIPTION
Increase shutil copyfileobj() buffer length from the default of 4KB to 512KB. In my setup this improved my network file transfer from ~8MB/s to over 60MB/s.