### PR TITLE
improve user script media extension handling

### DIFF
--- a/TorrentToMedia.py
+++ b/TorrentToMedia.py
@@ -95,6 +95,7 @@ def processTorrent(inputDirectory, inputName, inputCategory, inputHash, inputID,
     Torrent_NoLink = int(section.get("Torrent_NoLink", 0))
     keep_archive = int(section.get("keep_archive", 0))
     extract = int(section.get('extract', 0))
+    extensions = section.get('user_script_mediaExtensions', "").lower().split(',')
     uniquePath = int(section.get("unique_path", 1))
 
     if clientAgent != 'manual':
@@ -138,9 +139,9 @@ def processTorrent(inputDirectory, inputName, inputCategory, inputHash, inputID,
     now = datetime.datetime.now()
 
     if extract == 1:
-        inputFiles = core.listMediaFiles(inputDirectory, archives=False)
+        inputFiles = core.listMediaFiles(inputDirectory, archives=False, other=True, otherext=extensions)
     else:
-        inputFiles = core.listMediaFiles(inputDirectory)
+        inputFiles = core.listMediaFiles(inputDirectory, other=True, otherext=extensions)
     logger.debug("Found {0} files in {1}".format(len(inputFiles), inputDirectory))
     for inputFile in inputFiles:
         filePath = os.path.dirname(inputFile)

--- a/core/nzbToMediaUserScript.py
+++ b/core/nzbToMediaUserScript.py
@@ -11,7 +11,7 @@ def external_script(outputDestination, torrentName, torrentLabel, settings):
     final_result = 0  # start at 0.
     num_files = 0
     try:
-        core.USER_SCRIPT_MEDIAEXTENSIONS = settings["user_script_mediaExtensions"]
+        core.USER_SCRIPT_MEDIAEXTENSIONS = settings["user_script_mediaExtensions"].lower()
         if isinstance(core.USER_SCRIPT_MEDIAEXTENSIONS, str):
             core.USER_SCRIPT_MEDIAEXTENSIONS = core.USER_SCRIPT_MEDIAEXTENSIONS.split(',')
     except:
@@ -51,7 +51,7 @@ def external_script(outputDestination, torrentName, torrentLabel, settings):
             filePath = core.os.path.join(dirpath, file)
             fileName, fileExtension = os.path.splitext(file)
 
-            if fileExtension in core.USER_SCRIPT_MEDIAEXTENSIONS or "ALL" in core.USER_SCRIPT_MEDIAEXTENSIONS:
+            if fileExtension in core.USER_SCRIPT_MEDIAEXTENSIONS or "all" in core.USER_SCRIPT_MEDIAEXTENSIONS:
                 num_files += 1
                 if core.USER_SCRIPT_RUNONCE == 1 and num_files > 1:  # we have already run once, so just continue to get number of files.
                     continue

--- a/core/nzbToMediaUtil.py
+++ b/core/nzbToMediaUtil.py
@@ -960,7 +960,7 @@ def is_archive_file(filename):
     return False
 
 
-def isMediaFile(mediafile, media=True, audio=True, meta=True, archives=True):
+def isMediaFile(mediafile, media=True, audio=True, meta=True, archives=True, other=False, otherext=[]):
     fileName, fileExt = os.path.splitext(mediafile)
 
     try:
@@ -969,22 +969,22 @@ def isMediaFile(mediafile, media=True, audio=True, meta=True, archives=True):
             return False
     except:
         pass
-
     if (media and fileExt.lower() in core.MEDIACONTAINER) \
             or (audio and fileExt.lower() in core.AUDIOCONTAINER) \
             or (meta and fileExt.lower() in core.METACONTAINER) \
-            or (archives and is_archive_file(mediafile)):
+            or (archives and is_archive_file(mediafile)) \
+            or (other and (fileExt.lower() in otherext or 'all' in otherext)):
         return True
     else:
         return False
 
 
-def listMediaFiles(path, minSize=0, delete_ignored=0, media=True, audio=True, meta=True, archives=True):
+def listMediaFiles(path, minSize=0, delete_ignored=0, media=True, audio=True, meta=True, archives=True, other=False, otherext=[]):
     files = []
     if not os.path.isdir(path):
         if os.path.isfile(path):  # Single file downloads.
             curFile = os.path.split(path)[1]
-            if isMediaFile(curFile, media, audio, meta, archives):
+            if isMediaFile(curFile, media, audio, meta, archives, other, otherext):
                 # Optionally ignore sample files
                 if is_sample(path) or not is_minSize(path, minSize):
                     if delete_ignored == 1:
@@ -1004,9 +1004,9 @@ def listMediaFiles(path, minSize=0, delete_ignored=0, media=True, audio=True, me
 
         # if it's a folder do it recursively
         if os.path.isdir(fullCurFile) and not curFile.startswith('.'):
-            files += listMediaFiles(fullCurFile, minSize, delete_ignored, media, audio, meta, archives)
+            files += listMediaFiles(fullCurFile, minSize, delete_ignored, media, audio, meta, archives, other, otherext)
 
-        elif isMediaFile(curFile, media, audio, meta, archives):
+        elif isMediaFile(curFile, media, audio, meta, archives, other, otherext):
             # Optionally ignore sample files
             if is_sample(fullCurFile) or not is_minSize(fullCurFile, minSize):
                 if delete_ignored == 1:


### PR DESCRIPTION
When processing non-media downloads, TorrentToMedia had a tendency to delete anything that wasn't a media file, even if it was specified as an extension to process using a userscript.