### PR TITLE
Import mode configuration

### DIFF
--- a/autoProcessMedia.cfg.spec
+++ b/autoProcessMedia.cfg.spec
@@ -99,8 +99,8 @@
         remote_path = 0
         ##### Set to path where download client places completed downloads locally for this category
         watch_dir =
-		##### Set to define import behavior Move or Copy
-		importMode = Copy
+        ##### Set to define import behavior Move or Copy
+        importMode = Copy
 
 [SickBeard]
     #### autoProcessing for TV Series
@@ -169,8 +169,8 @@
         remote_path = 0
         ##### Set to path where download client places completed downloads locally for this category
         watch_dir =
-		##### Set to define import behavior Move or Copy
-		importMode = Copy
+        ##### Set to define import behavior Move or Copy
+        importMode = Copy
 
 [HeadPhones]
     #### autoProcessing for Music

--- a/autoProcessMedia.cfg.spec
+++ b/autoProcessMedia.cfg.spec
@@ -99,6 +99,8 @@
         remote_path = 0
         ##### Set to path where download client places completed downloads locally for this category
         watch_dir =
+		##### Set to define import behavior Move or Copy
+		importMode = Copy
 
 [SickBeard]
     #### autoProcessing for TV Series
@@ -167,6 +169,8 @@
         remote_path = 0
         ##### Set to path where download client places completed downloads locally for this category
         watch_dir =
+		##### Set to define import behavior Move or Copy
+		importMode = Copy
 
 [HeadPhones]
     #### autoProcessing for Music

--- a/core/autoProcess/autoProcessMovie.py
+++ b/core/autoProcess/autoProcessMovie.py
@@ -148,6 +148,11 @@ class autoProcessMovie(object):
             method = cfg["method"]
         else:
             method = None
+        #added importMode for Radarr config
+        if section == "Radarr":
+            importMode = cfg.get("importMode","Move")
+        else:
+            importMode = None
         delete_failed = int(cfg["delete_failed"])
         wait_for = int(cfg["wait_for"])
         ssl = int(cfg.get("ssl", 0))
@@ -287,7 +292,7 @@ class autoProcessMovie(object):
                 logger.postprocess("Starting {0} scan for {1}".format(method, inputName), section)
 
             if section == "Radarr":
-                payload = {'name': 'DownloadedMoviesScan', 'path': params['media_folder'], 'downloadClientId': download_id}
+                payload = {'name': 'DownloadedMoviesScan', 'path': params['media_folder'], 'downloadClientId': download_id,'importMode' : importMode}
                 if not download_id:
                     payload.pop("downloadClientId")
                 logger.debug("Opening URL: {0} with PARAMS: {1}".format(baseURL, payload), section)

--- a/core/autoProcess/autoProcessTV.py
+++ b/core/autoProcess/autoProcessTV.py
@@ -87,6 +87,8 @@ class autoProcessTV(object):
             extract = 0
         else:
             extract = int(cfg.get("extract", 0))
+        #get importmode, default to "Move" for consistency with legacy
+        importMode = cfg.get("importMode","Move")
 
         if not os.path.isdir(dirName) and os.path.isfile(dirName):  # If the input directory is a file, assume single file download and split dir/name.
             dirName = os.path.split(os.path.normpath(dirName))[0]
@@ -270,10 +272,10 @@ class autoProcessTV(object):
             # params = {'sortKey': 'series.title', 'page': 1, 'pageSize': 1, 'sortDir': 'asc'}
             if remote_path:
                 logger.debug("remote_path: {0}".format(remoteDir(dirName)), section)
-                data = {"name": "DownloadedEpisodesScan", "path": remoteDir(dirName), "downloadClientId": download_id, "importMode": "Move"}
+                data = {"name": "DownloadedEpisodesScan", "path": remoteDir(dirName), "downloadClientId": download_id, "importMode": importMode}
             else:
                 logger.debug("path: {0}".format(dirName), section)
-                data = {"name": "DownloadedEpisodesScan", "path": dirName, "downloadClientId": download_id, "importMode": "Move"}
+                data = {"name": "DownloadedEpisodesScan", "path": dirName, "downloadClientId": download_id, "importMode": importMode}
             if not download_id:
                 data.pop("downloadClientId")
             data = json.dumps(data)

--- a/core/nzbToMediaConfig.py
+++ b/core/nzbToMediaConfig.py
@@ -384,8 +384,9 @@ class ConfigObj(configobj.ConfigObj, Section):
             envCatKey = 'NZBPO_NDCATEGORY'
             envKeys = ['ENABLED', 'HOST', 'APIKEY', 'PORT', 'SSL', 'WEB_ROOT', 'WATCH_DIR', 'FORK', 'DELETE_FAILED',
                        'TORRENT_NOLINK', 'NZBEXTRACTIONBY', 'WAIT_FOR', 'DELETE_FAILED', 'REMOTE_PATH']
+            #new cfgKey added for importMode
             cfgKeys = ['enabled', 'host', 'apikey', 'port', 'ssl', 'web_root', 'watch_dir', 'fork', 'delete_failed',
-                       'Torrent_NoLink', 'nzbExtractionBy', 'wait_for', 'delete_failed', 'remote_path']
+                       'Torrent_NoLink', 'nzbExtractionBy', 'wait_for', 'delete_failed', 'remote_path','importMode']
             if envCatKey in os.environ:
                 for index in range(len(envKeys)):
                     key = 'NZBPO_ND{index}'.format(index=envKeys[index])
@@ -403,8 +404,9 @@ class ConfigObj(configobj.ConfigObj, Section):
             envCatKey = 'NZBPO_RACATEGORY'
             envKeys = ['ENABLED', 'HOST', 'APIKEY', 'PORT', 'SSL', 'WEB_ROOT', 'WATCH_DIR', 'FORK', 'DELETE_FAILED',
                        'TORRENT_NOLINK', 'NZBEXTRACTIONBY', 'WAIT_FOR', 'DELETE_FAILED', 'REMOTE_PATH', 'OMDBAPIKEY']
+            #new cfgKey added for importMode
             cfgKeys = ['enabled', 'host', 'apikey', 'port', 'ssl', 'web_root', 'watch_dir', 'fork', 'delete_failed',
-                       'Torrent_NoLink', 'nzbExtractionBy', 'wait_for', 'delete_failed', 'remote_path', 'omdbapikey']
+                       'Torrent_NoLink', 'nzbExtractionBy', 'wait_for', 'delete_failed', 'remote_path', 'omdbapikey','importMode']
             if envCatKey in os.environ:
                 for index in range(len(envKeys)):
                     key = 'NZBPO_RA{index}'.format(index=envKeys[index])


### PR DESCRIPTION
**Description:**
Updates to allow users to specify importMode for NzbDrone/Sonarr and Radarr using NzbDrone/Sonarr/Radarr API parameter importMode enumerations in autoProcessMedia.cfg

**Behavior:**
If user specifies importMode = Copy, the downloaded file is retained in the completed download directory and copied to the specified movie/tv directory.
If the user specifies importMode = Move, the downloaded file is moved from the completed download directory to the specified movie/tv directory. No downloaded copy is retained in the completed download directory
The behavior defaults to Move to retain legacy behavior