### PR TITLE
Fix IOError on cleanup when git not found

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -53,7 +53,7 @@ def clean_bytecode():
         print(result)
     except subprocess.CalledProcessError as error:
         sys.exit('Error Code: {}'.format(error.returncode))
-    except OSError as error:
+    except (IOError, OSError) as error:
         sys.exit('Error: {}'.format(error))
     else:
         return result
@@ -70,7 +70,7 @@ def clean_folders(*paths):
         )
     except subprocess.CalledProcessError as error:
         sys.exit('Error Code: {}'.format(error.returncode))
-    except OSError as error:
+    except (IOError, OSError) as error:
         sys.exit('Error: {}'.format(error))
     else:
         return result


### PR DESCRIPTION
On posix systems IOError is raised when git is not found

In Python 3 IOError is an alias for OSError.
In Python 2 IOError is not caught by OSError so we must catch both.

Fixes #1460