### PR TITLE
Refactor/iso matching

### DIFF
--- a/core/transcoder.py
+++ b/core/transcoder.py
@@ -646,8 +646,8 @@ def rip_iso(item, new_dir, bitbucket):
         print_cmd(cmd)
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=bitbucket)
         out, err = proc.communicate()
-        file_list = [re.match(r'.+(VIDEO_TS[/\\]VTS_[0-9][0-9]_[0-9].[Vv][Oo][Bb])', line.decode()).groups()[0] for line in
-                     out.splitlines() if re.match(r'.+VIDEO_TS[/\\]VTS_[0-9][0-9]_[0-9].[Vv][Oo][Bb]', line.decode())]
+        file_list = [re.match(r'.+(VIDEO_TS[/\\]VTS_[0-9][0-9]_[0-9].[Vv][Oo][Bb])', line).groups()[0] for line in
+                     out.decode().splitlines() if re.match(r'.+VIDEO_TS[/\\]VTS_[0-9][0-9]_[0-9].[Vv][Oo][Bb]', line)]
         combined = []
         for n in range(99):
             concat = []

--- a/core/transcoder.py
+++ b/core/transcoder.py
@@ -646,8 +646,15 @@ def rip_iso(item, new_dir, bitbucket):
         print_cmd(cmd)
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=bitbucket)
         out, err = proc.communicate()
-        file_list = [re.match(r'.+(VIDEO_TS[/\\]VTS_[0-9][0-9]_[0-9].[Vv][Oo][Bb])', line).groups()[0] for line in
-                     out.decode().splitlines() if re.match(r'.+VIDEO_TS[/\\]VTS_[0-9][0-9]_[0-9].[Vv][Oo][Bb]', line)]
+        file_match_gen = (
+            re.match(r'.+(VIDEO_TS[/\\]VTS_[0-9][0-9]_[0-9].[Vv][Oo][Bb])', line)
+            for line in out.decode().splitlines()
+        )
+        file_list = [
+            file_match.groups()[0]
+            for file_match in file_match_gen
+            if file_match
+        ]
         combined = []
         for n in range(99):
             concat = []


### PR DESCRIPTION
This cleans up the ISO matching by decoding the entire process output a single time instead of once per line.

To avoid using the regex twice per file, I also split the generation of the file list into two steps:
1. regex match the ISO file pattern (using a generator to reduce memory footprint by avoiding an extra list)
2. filter non-matching results and return match group 0 for each match (to avoid the second regex)
