### PR TITLE
Fix absolute imports for qbittorrent and utorrent in Python 2.7

### DIFF
--- a/core/plugins/downloaders/torrent/qbittorrent.py
+++ b/core/plugins/downloaders/torrent/qbittorrent.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from qbittorrent import Client as qBittorrentClient
 
 import core

--- a/core/plugins/downloaders/torrent/utorrent.py
+++ b/core/plugins/downloaders/torrent/utorrent.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from utorrent.client import UTorrentClient
 
 import core


### PR DESCRIPTION
Python 2.7 and Python 3.x handle imports differently.  

In Python 2.7, when `core.plugins.downloaders.torrent.qbittorrent` tries to import `Client` from the `qbittorrent` library, it tries the local `qbittorrent` plugin and fails.  Same for utorrent.

This PR adds `from __future__ import absolute_import` to the affected files to enforce Python 3.x style absolute imports. 

Fixes #1570