### PR TITLE
remove .encode which creates byte vs string comparison issues.

### DIFF
--- a/TorrentToMedia.py
+++ b/TorrentToMedia.py
@@ -60,14 +60,14 @@ def process_torrent(input_directory, input_name, input_category, input_hash, inp
         input_category = 'UNCAT'
 
     usercat = input_category
-    try:
-        input_name = input_name.encode(core.SYS_ENCODING)
-    except UnicodeError:
-        pass
-    try:
-        input_directory = input_directory.encode(core.SYS_ENCODING)
-    except UnicodeError:
-        pass
+    #try:
+    #    input_name = input_name.encode(core.SYS_ENCODING)
+    #except UnicodeError:
+    #    pass
+    #try:
+    #    input_directory = input_directory.encode(core.SYS_ENCODING)
+    #except UnicodeError:
+    #    pass
 
     logger.debug('Determined Directory: {0} | Name: {1} | Category: {2}'.format
                  (input_directory, input_name, input_category))
@@ -125,10 +125,10 @@ def process_torrent(input_directory, input_name, input_category, input_hash, inp
     else:
         output_destination = os.path.normpath(
             core.os.path.join(core.OUTPUT_DIRECTORY, input_category))
-    try:
-        output_destination = output_destination.encode(core.SYS_ENCODING)
-    except UnicodeError:
-        pass
+    #try:
+    #    output_destination = output_destination.encode(core.SYS_ENCODING)
+    #except UnicodeError:
+    #    pass
 
     if output_destination in input_directory:
         output_destination = input_directory
@@ -170,10 +170,10 @@ def process_torrent(input_directory, input_name, input_category, input_hash, inp
                     core.os.path.join(output_destination, os.path.basename(file_path)), full_file_name)
                 logger.debug('Setting outputDestination to {0} to preserve folder structure'.format
                              (os.path.dirname(target_file)))
-        try:
-            target_file = target_file.encode(core.SYS_ENCODING)
-        except UnicodeError:
-            pass
+        #try:
+        #    target_file = target_file.encode(core.SYS_ENCODING)
+        #except UnicodeError:
+        #    pass
         if root == 1:
             if not found_file:
                 logger.debug('Looking for {0} in: {1}'.format(input_name, inputFile))
@@ -350,15 +350,15 @@ def main(args):
                     if client_agent.lower() not in core.TORRENT_CLIENTS:
                         continue
 
-                    try:
-                        dir_name = dir_name.encode(core.SYS_ENCODING)
-                    except UnicodeError:
-                        pass
+                    #try:
+                    #    dir_name = dir_name.encode(core.SYS_ENCODING)
+                    #except UnicodeError:
+                    #    pass
                     input_name = os.path.basename(dir_name)
-                    try:
-                        input_name = input_name.encode(core.SYS_ENCODING)
-                    except UnicodeError:
-                        pass
+                    #try:
+                    #    input_name = input_name.encode(core.SYS_ENCODING)
+                    #except UnicodeError:
+                    #    pass
 
                     results = process_torrent(dir_name, input_name, subsection, input_hash or None, input_id or None,
                                               client_agent)

--- a/core/utils/identification.py
+++ b/core/utils/identification.py
@@ -90,14 +90,14 @@ def find_imdbid(dir_name, input_name, omdb_api_key):
 def category_search(input_directory, input_name, input_category, root, categories):
     tordir = False
 
-    try:
-        input_name = input_name.encode(core.SYS_ENCODING)
-    except Exception:
-        pass
-    try:
-        input_directory = input_directory.encode(core.SYS_ENCODING)
-    except Exception:
-        pass
+    #try:
+    #    input_name = input_name.encode(core.SYS_ENCODING)
+    #except Exception:
+    #    pass
+    #try:
+    #    input_directory = input_directory.encode(core.SYS_ENCODING)
+    #except Exception:
+    #    pass
 
     if input_directory is None:  # =Nothing to process here.
         return input_directory, input_name, input_category, root

--- a/core/utils/naming.py
+++ b/core/utils/naming.py
@@ -20,10 +20,10 @@ def sanitize_name(name):
 
     # remove leading/trailing periods and spaces
     name = name.strip(' .')
-    try:
-        name = name.encode(core.SYS_ENCODING)
-    except Exception:
-        pass
+    #try:
+    #    name = name.encode(core.SYS_ENCODING)
+    #except Exception:
+    #    pass
 
     return name
 


### PR DESCRIPTION
# Description

While python2.7 worked for TorrentToMedia, using python3.X resulted in
```
    pathlist = os.path.normpath(input_directory).split(os.sep)
TypeError: a bytes-like object is required, not 'str'
```

Fixes # 1582

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested running various scenarios on my NAS, however this NAS has never demonstrated or resulted in the encoding issues that lead to these .encoding() functions being added.

More work will be required, but this is a quick fix to get TorrentToMedia functional on Python3.X

**Test Configuration**:

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
