### PR TITLE
Add pywin32 to setup.py install_requires on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(
     author_email='fock_wulf@hotmail.com',
     url='https://github.com/clinton-hall/nzbToMedia',
     packages=['core'],
+    install_requires=[
+        'pywin32;platform_system=="Windows"',
+    ],
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
# Description

Installs PyWin32 on windows when running setup.py

## Type of change

- [X] New feature (non-breaking change which adds functionality) 

# How Has This Been Tested?

Until nzbToMedia is installable as a library, this will not provide any change to existing functionality.

# Checklist:
- [x] I have based this change on the nightly branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
