### PR TITLE
Flake8/quotes

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -110,7 +110,7 @@ FORKS = {
     FORK_MEDUSA: {'proc_dir': None, 'failed': None, 'process_method': None, 'force': None, 'delete_on': None, 'ignore_subs': None},
     FORK_MEDUSA_API: {'path': None, 'failed': None, 'process_method': None, 'force_replace': None, 'return_data': None, 'type': None, 'delete_files': None, 'is_priority': None},
     FORK_SICKGEAR: {'dir': None, 'failed': None, 'process_method': None, 'force': None},
-    FORK_STHENO: {"proc_dir": None, "failed": None, "process_method": None, "force": None, "delete_on": None, "ignore_subs": None},
+    FORK_STHENO: {'proc_dir': None, 'failed': None, 'process_method': None, 'force': None, 'delete_on': None, 'ignore_subs': None},
 }
 ALL_FORKS = {k: None for k in set(list(itertools.chain.from_iterable([FORKS[x].keys() for x in FORKS.keys()])))}
 

--- a/core/auto_process/tv.py
+++ b/core/auto_process/tv.py
@@ -266,7 +266,7 @@ def process(section, dir_name, input_name=None, failed=False, client_agent='manu
         if apikey:
             url = '{0}{1}:{2}{3}/api/{4}/?cmd=postprocess'.format(protocol, host, port, web_root, apikey)
         elif fork == 'Stheno':
-            url = "{0}{1}:{2}{3}/home/postprocess/process_episode".format(protocol, host, port, web_root)
+            url = '{0}{1}:{2}{3}/home/postprocess/process_episode'.format(protocol, host, port, web_root)
         else:
             url = '{0}{1}:{2}{3}/home/postprocess/processEpisode'.format(protocol, host, port, web_root)
     elif section == 'NzbDrone':

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ per-file-ignores =
 deps =
     flake8
     flake8-commas
+    flake8-quotes
 skip_install = true
 commands =
     flake8 core tests setup.py


### PR DESCRIPTION
# Description

Add flake8-quotes to tox to enforce consistent quote usage.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
pip install --upgrade tox
tox
```

**Test Configuration**:
Win 10
Python 2.7, 3.5, 3.6, and 3.7

# Checklist:
- [x] I have based this change on the nightly branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
