### PR TITLE
Fix/flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ statistics = True
 ignore =
 ;   -- flake8 --
 ;    E501 line too long
-;    E501
+    E501
 
 ;   -- flake8-docstrings --
 ;    D100 Missing docstring in public module
@@ -57,7 +57,7 @@ ignore =
 per-file-ignores =
 ;    F401 imported but unused
 ;    E402 module level import not at top of file
-;    core/__init__.py: E402, F401
+    core/__init__.py: E402, F401
     core/utils/__init__.py: F401
     core/plugins/downloaders/configuration.py: F401
     core/plugins/downloaders/utils.py: F401

--- a/tox.ini
+++ b/tox.ini
@@ -33,12 +33,6 @@ commands =
 max-line-length = 79
 verbose = 2
 statistics = True
-select =
-;   -- flake8-bugbear --
-;    B902 Invalid first argument used for instance method.
-;    B903 Data class should either be immutable or use __slots__ to save memory.
-    B902, B903
-
 ignore =
 ;   -- flake8 --
 ;    E501 line too long
@@ -78,7 +72,15 @@ deps =
     flake8-quotes
 skip_install = true
 commands =
+;   ** PRIMARY TESTS **
+;   Run flake8 tests (with plugins) using default test selections
     flake8 core tests setup.py
+;   ** SELECTIVE TESTS **
+;   Run flake8 tests (with plugins) for specific optional codes defined below
+;   -- flake8-bugbear --
+;    B902 Invalid first argument used for instance method.
+;    B903 Data class should be immutable or use __slots__ to save memory.
+    flake8 core tests setup.py --select=B902,B903
 
 [coverage:run]
 omit =

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ statistics = True
 ignore =
 ;   -- flake8 --
 ;    E501 line too long
-    E501
+;    E501
 
 ;   -- flake8-docstrings --
 ;    D100 Missing docstring in public module
@@ -57,7 +57,7 @@ ignore =
 per-file-ignores =
 ;    F401 imported but unused
 ;    E402 module level import not at top of file
-    core/__init__.py: E402, F401
+;    core/__init__.py: E402, F401
     core/utils/__init__.py: F401
     core/plugins/downloaders/configuration.py: F401
     core/plugins/downloaders/utils.py: F401


### PR DESCRIPTION
# Description

When using the --select option to select optional tests disables all default flake8 test selections.  A fix for this is to explicitly select the default tests as well, however if a new plugin is added or an existing plugin is updated which adds new tests, they could easily be missed in the select statement.  To avoid this, we will run flake8 twice, once with defaults, and once with selected optional tests.

Fixes # 1602

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Temporarily disable some flake8 ignores
- Run `tox -e check`
- Confirm errors are reported
- Re-enable flake8 ignores
- Run `tox -e check`
- Confirm flake8 is called with and without selective tests

**Test Configuration**:
Windows 10
Python 2.7, 3.5, 3.6, 3.7

# Checklist:
- [x] I have based this change on the nightly branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
