### PR TITLE
Add optional flake8 tests to selective testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
 
 [flake8]
 max-line-length = 79
+max-doc-length = 79
 verbose = 2
 statistics = True
 exclude =
@@ -45,7 +46,8 @@ exclude =
 ignore =
 ;   -- flake8 --
 ;    E501 line too long
-    E501
+;    W505 doc line too long
+    E501, W505
 
 ;   -- flake8-docstrings --
 ;    D100 Missing docstring in public module
@@ -89,10 +91,18 @@ commands =
     flake8
 ;   ** SELECTIVE TESTS **
 ;   Run flake8 tests (with plugins) for specific optional codes defined below
+;   -- flake8 --
+;    E123 closing bracket does not match indentation of opening bracket’s line
+;    E226 missing whitespace around arithmetic operator
+;    E241 multiple spaces after ‘,’
+;    E242 tab after ‘,’
+;    E704 multiple statements on one line
+;    W504 line break after binary operator
+;    W505 doc line too long
 ;   -- flake8-bugbear --
 ;    B902 Invalid first argument used for instance method.
 ;    B903 Data class should be immutable or use __slots__ to save memory.
-    flake8 --select=B902,B903
+flake8 --select=B902,B903,E123,E226,E241,E242,E704,W504,W505
 
 [coverage:run]
 omit =


### PR DESCRIPTION
# Description

Adds the following optional flake8 tests to code quality checks:

- E123 closing bracket does not match indentation of opening bracket’s line
- E226 missing whitespace around arithmetic operator
- E241 multiple spaces after ‘,’
- E242 tab after ‘,’
- E704 multiple statements on one line
- W504 line break after binary operator
- W505 doc line too long

Ignore W505 (doc string length) for now

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
pip install --upgrade tox
tox
```

**Test Configuration**:
Windows 10
Python 2.7, 3.5, 3.6, 3.7

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
