### PR TITLE
Don't replace apostrophes in qBittorrent input_name

### DIFF
--- a/core/utils/parsers.py
+++ b/core/utils/parsers.py
@@ -127,7 +127,11 @@ def parse_qbittorrent(args):
     except Exception:
         input_directory = ''
     try:
-        input_name = cur_input[1].replace('\'', '')
+        input_name = cur_input[1]
+        if input_name[0] == '\'':
+            input_name = input_name[1:]
+        if input_name[-1] == '\'':
+            input_name = input_name[:-1]
     except Exception:
         input_name = ''
     try:


### PR DESCRIPTION
# Description

Don't replace apostrophes in qBittorrent input_name - only trim if found at beginning/end of string.

This stops nzbtomedia processing the entire download folder when asked to process a folder with apostrophes in the title

Fixes #1624

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Re-ran with same input torrents, folders, it worked.

**Test Configuration**:

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
