### PR TITLE
don't crash when no optionalParameters. Fixes #1630

### DIFF
--- a/core/forks.py
+++ b/core/forks.py
@@ -114,11 +114,14 @@ def auto_fork(section, input_category):
                 else:
                     json_data = json_data.get('data', json_data)
 
-                optional_parameters = json_data['optionalParameters'].keys()
-                # Find excess parameters
-                excess_parameters = set(params).difference(optional_parameters)
-                logger.debug('Removing excess parameters: {}'.format(sorted(excess_parameters)))
-                rem_params.extend(excess_parameters)
+                try:
+                    optional_parameters = json_data['optionalParameters'].keys()
+                    # Find excess parameters
+                    excess_parameters = set(params).difference(optional_parameters)
+                    logger.debug('Removing excess parameters: {}'.format(sorted(excess_parameters)))
+                    rem_params.extend(excess_parameters)
+                except:
+                    logger.error('Failed to identify optionalParameters')
             else:
                 # Find excess parameters
                 rem_params.extend(


### PR DESCRIPTION
# Description

Script crashed when no "optionalParameters" were returned by Sick* fork (reporting case came from SickGear)

Fixes #1630

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
