### PR TITLE
Fix3

### DIFF
--- a/TorrentToMedia.py
+++ b/TorrentToMedia.py
@@ -70,14 +70,6 @@ def process_torrent(input_directory, input_name, input_category, input_hash, inp
         input_category = 'UNCAT'
 
     usercat = input_category
-    # try:
-    #    input_name = input_name.encode(core.SYS_ENCODING)
-    # except UnicodeError:
-    #    pass
-    # try:
-    #    input_directory = input_directory.encode(core.SYS_ENCODING)
-    # except UnicodeError:
-    #    pass
 
     logger.debug('Determined Directory: {0} | Name: {1} | Category: {2}'.format
                  (input_directory, input_name, input_category))
@@ -135,10 +127,6 @@ def process_torrent(input_directory, input_name, input_category, input_hash, inp
     else:
         output_destination = os.path.normpath(
             core.os.path.join(core.OUTPUT_DIRECTORY, input_category))
-    # try:
-    #    output_destination = output_destination.encode(core.SYS_ENCODING)
-    # except UnicodeError:
-    #    pass
 
     if output_destination in input_directory:
         output_destination = input_directory
@@ -180,10 +168,6 @@ def process_torrent(input_directory, input_name, input_category, input_hash, inp
                     core.os.path.join(output_destination, os.path.basename(file_path)), full_file_name)
                 logger.debug('Setting outputDestination to {0} to preserve folder structure'.format
                              (os.path.dirname(target_file)))
-        # try:
-        #    target_file = target_file.encode(core.SYS_ENCODING)
-        # except UnicodeError:
-        #    pass
         if root == 1:
             if not found_file:
                 logger.debug('Looking for {0} in: {1}'.format(input_name, inputFile))
@@ -362,15 +346,7 @@ def main(args):
                     if client_agent.lower() not in core.TORRENT_CLIENTS:
                         continue
 
-                    # try:
-                    #    dir_name = dir_name.encode(core.SYS_ENCODING)
-                    # except UnicodeError:
-                    #    pass
                     input_name = os.path.basename(dir_name)
-                    # try:
-                    #    input_name = input_name.encode(core.SYS_ENCODING)
-                    # except UnicodeError:
-                    #    pass
 
                     results = process_torrent(dir_name, input_name, subsection, input_hash or None, input_id or None,
                                               client_agent)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -99,10 +99,12 @@ FORK_FAILED = 'failed'
 FORK_FAILED_TORRENT = 'failed-torrent'
 FORK_SICKRAGE = 'SickRage'
 FORK_SICKCHILL = 'SickChill'
+FORK_SICKCHILL_API = 'SickChill-api'
 FORK_SICKBEARD_API = 'SickBeard-api'
 FORK_MEDUSA = 'Medusa'
 FORK_MEDUSA_API = 'Medusa-api'
 FORK_SICKGEAR = 'SickGear'
+FORK_SICKGEAR_API = 'SickGear-api'
 FORK_STHENO = 'Stheno'
 
 FORKS = {
@@ -111,10 +113,12 @@ FORKS = {
     FORK_FAILED_TORRENT: {'dir': None, 'failed': None, 'process_method': None},
     FORK_SICKRAGE: {'proc_dir': None, 'failed': None, 'process_method': None, 'force': None, 'delete_on': None},
     FORK_SICKCHILL: {'proc_dir': None, 'failed': None, 'process_method': None, 'force': None, 'delete_on': None, 'force_next': None},
+    FORK_SICKCHILL_API: {'path': None, 'failed': None, 'process_method': None, 'force_replace': None, 'return_data': None, 'type': None, 'delete': None, 'force_next': None, 'is_priority': None},
     FORK_SICKBEARD_API: {'path': None, 'failed': None, 'process_method': None, 'force_replace': None, 'return_data': None, 'type': None, 'delete': None, 'force_next': None},
     FORK_MEDUSA: {'proc_dir': None, 'failed': None, 'process_method': None, 'force': None, 'delete_on': None, 'ignore_subs': None},
     FORK_MEDUSA_API: {'path': None, 'failed': None, 'process_method': None, 'force_replace': None, 'return_data': None, 'type': None, 'delete_files': None, 'is_priority': None},
     FORK_SICKGEAR: {'dir': None, 'failed': None, 'process_method': None, 'force': None},
+    FORK_SICKGEAR_API: {'path': None, 'process_method': None, 'force_replace': None, 'return_data': None, 'type': None, 'is priority': None},
     FORK_STHENO: {'proc_dir': None, 'failed': None, 'process_method': None, 'force': None, 'delete_on': None, 'ignore_subs': None},
 }
 ALL_FORKS = {k: None for k in set(list(itertools.chain.from_iterable([FORKS[x].keys() for x in FORKS.keys()])))}

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -198,6 +198,7 @@ META_CONTAINER = []
 
 SECTIONS = []
 CATEGORIES = []
+FORK_SET = []
 
 MOUNTED = None
 GETSUBS = False
@@ -859,6 +860,7 @@ def configure_passwords_file():
 def configure_sections(section):
     global SECTIONS
     global CATEGORIES
+    global FORK_SET
     # check for script-defied section and if None set to allow sections
     SECTIONS = CFG[
         tuple(x for x in CFG if CFG[x].sections and CFG[x].isenabled())
@@ -867,6 +869,7 @@ def configure_sections(section):
     for section, subsections in SECTIONS.items():
         CATEGORIES.extend([subsection for subsection in subsections if CFG[section][subsection].isenabled()])
     CATEGORIES = list(set(CATEGORIES))
+    FORK_SET = []
 
 
 def configure_utility_locations():

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -864,7 +864,6 @@ def configure_passwords_file():
 def configure_sections(section):
     global SECTIONS
     global CATEGORIES
-    global FORK_SET
     # check for script-defied section and if None set to allow sections
     SECTIONS = CFG[
         tuple(x for x in CFG if CFG[x].sections and CFG[x].isenabled())
@@ -873,7 +872,6 @@ def configure_sections(section):
     for section, subsections in SECTIONS.items():
         CATEGORIES.extend([subsection for subsection in subsections if CFG[section][subsection].isenabled()])
     CATEGORIES = list(set(CATEGORIES))
-    FORK_SET = []
 
 
 def configure_utility_locations():

--- a/core/forks.py
+++ b/core/forks.py
@@ -43,6 +43,7 @@ def api_check(r, params, rem_params):
 
 
 def auto_fork(section, input_category):
+    global core.FORK_SET
     # auto-detect correct section
     # config settings
     if core.FORK_SET: # keep using determined fork for multiple (manual) post-processing

--- a/core/forks.py
+++ b/core/forks.py
@@ -43,11 +43,10 @@ def api_check(r, params, rem_params):
 
 
 def auto_fork(section, input_category):
-    global core.FORK_SET
     # auto-detect correct section
     # config settings
     if core.FORK_SET: # keep using determined fork for multiple (manual) post-processing
-        logger.info('{section}:{category} fork set to {fork}'.format
+        logger.info('{section}:{category} fork already set to {fork}'.format
                     (section=section, category=input_category, fork=core.FORK_SET[0]))
         return core.FORK_SET[0], core.FORK_SET[1]
 

--- a/core/forks.py
+++ b/core/forks.py
@@ -45,6 +45,10 @@ def api_check(r, params, rem_params):
 def auto_fork(section, input_category):
     # auto-detect correct section
     # config settings
+    if core.FORK_SET: # keep using determined fork for multiple (manual) post-processing
+        logger.info('{section}:{category} fork set to {fork}'.format
+                    (section=section, category=input_category, fork=core.FORK_SET[0]))
+        return core.FORK_SET[0], core.FORK_SET[1]
 
     cfg = dict(core.CFG[section][input_category])
 
@@ -168,4 +172,5 @@ def auto_fork(section, input_category):
 
     logger.info('{section}:{category} fork set to {fork}'.format
                 (section=section, category=input_category, fork=fork[0]))
+    core.FORK_SET = fork
     return fork[0], fork[1]

--- a/core/utils/identification.py
+++ b/core/utils/identification.py
@@ -96,15 +96,6 @@ def find_imdbid(dir_name, input_name, omdb_api_key):
 def category_search(input_directory, input_name, input_category, root, categories):
     tordir = False
 
-    # try:
-    #    input_name = input_name.encode(core.SYS_ENCODING)
-    # except Exception:
-    #    pass
-    # try:
-    #    input_directory = input_directory.encode(core.SYS_ENCODING)
-    # except Exception:
-    #    pass
-
     if input_directory is None:  # =Nothing to process here.
         return input_directory, input_name, input_category, root
 

--- a/core/utils/naming.py
+++ b/core/utils/naming.py
@@ -26,10 +26,6 @@ def sanitize_name(name):
 
     # remove leading/trailing periods and spaces
     name = name.strip(' .')
-    # try:
-    #    name = name.encode(core.SYS_ENCODING)
-    # except Exception:
-    #    pass
 
     return name
 

--- a/nzbToMedia.py
+++ b/nzbToMedia.py
@@ -975,12 +975,12 @@ def main(args, section=None):
 
                     try:
                         dir_name = dir_name.encode(core.SYS_ENCODING)
-                    except UnicodeError:
+                    except:
                         pass
                     input_name = os.path.basename(dir_name)
                     try:
                         input_name = input_name.encode(core.SYS_ENCODING)
-                    except UnicodeError:
+                    except:
                         pass
 
                     results = process(dir_name, input_name, 0, client_agent=client_agent,

--- a/nzbToMedia.py
+++ b/nzbToMedia.py
@@ -973,15 +973,7 @@ def main(args, section=None):
                     if client_agent and client_agent.lower() not in core.NZB_CLIENTS:
                         continue
 
-                    try:
-                        dir_name = dir_name.encode(core.SYS_ENCODING)
-                    except:
-                        pass
                     input_name = os.path.basename(dir_name)
-                    try:
-                        input_name = input_name.encode(core.SYS_ENCODING)
-                    except:
-                        pass
 
                     results = process(dir_name, input_name, 0, client_agent=client_agent,
                                       download_id=download_id or None, input_category=subsection)


### PR DESCRIPTION
# Description

When performing auto fork detection (Sick* forks) and doing a manual run with multiple directories/episodes, the multiple fork detections would fail causing the first directory to process and all subsequent processes to fail.

This change saves the detected fork into memory on the first fork detection and then re-uses this for all subsequent processes. This should reduce the api polling and therefore should also be more efficient.

Fixes #1637

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created test flow on test system to verify fork was saved and re-used. (Linux)
User tested fix3 branch and verified working. (Windows)
During testing, minor bugs detected which created errors when using python3. these were corrected and verified working in Python2 and Python3.

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes
