### PR TITLE
identify imdb ids with 8 digits

### DIFF
--- a/core/utils/identification.py
+++ b/core/utils/identification.py
@@ -23,14 +23,14 @@ def find_imdbid(dir_name, input_name, omdb_api_key):
 
     # find imdbid in dirName
     logger.info('Searching folder and file names for imdbID ...')
-    m = re.search(r'(tt\d{7})', dir_name + input_name)
+    m = re.search(r'(tt\d{7,8})', dir_name + input_name)
     if m:
         imdbid = m.group(1)
         logger.info('Found imdbID [{0}]'.format(imdbid))
         return imdbid
     if os.path.isdir(dir_name):
         for file in os.listdir(text_type(dir_name)):
-            m = re.search(r'(tt\d{7})', file)
+            m = re.search(r'(tt\d{7,8})', file)
             if m:
                 imdbid = m.group(1)
                 logger.info('Found imdbID [{0}] via file name'.format(imdbid))


### PR DESCRIPTION
# Description
Current code only matches first 7 digits of an imdbID. These IDs may now also be 8 digits long. (ie https://www.imdb.com/title/tt10001870/ )

I only added the 8th digit, but you might want to add a word boundry too. Since it will accept longer ids as a match, but truncates them. Didn't add it since it is more likely to break something I don't know about.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Only online regex tester.
Current regex: https://regex101.com/r/psUasI/3/
New regex: https://regex101.com/r/psUasI/2
With word boundry: https://regex101.com/r/psUasI/1

# Checklist:
- [x] I have based this change on the nightly branch
- [x] I have performed a self-review of my own code