### PR TITLE
Add word boundary to imdb match. #1639

### DIFF
--- a/core/utils/identification.py
+++ b/core/utils/identification.py
@@ -23,14 +23,14 @@ def find_imdbid(dir_name, input_name, omdb_api_key):
 
     # find imdbid in dirName
     logger.info('Searching folder and file names for imdbID ...')
-    m = re.search(r'(tt\d{7,8})', dir_name + input_name)
+    m = re.search(r'\b(tt\d{7,8})\b', dir_name + input_name)
     if m:
         imdbid = m.group(1)
         logger.info('Found imdbID [{0}]'.format(imdbid))
         return imdbid
     if os.path.isdir(dir_name):
         for file in os.listdir(text_type(dir_name)):
-            m = re.search(r'(tt\d{7,8})', file)
+            m = re.search(r'\b(tt\d{7,8})\b', file)
             if m:
                 imdbid = m.group(1)
                 logger.info('Found imdbID [{0}] via file name'.format(imdbid))


### PR DESCRIPTION
# Description

Prevents matching (and truncating) longer ids.
Thanks @currently-off-my-rocker

Fixes issue identified in PR #1639

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Regex Tests provided by @currently-off-my-rocker

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
