### PR TITLE
fix empty dir_name #1673

### DIFF
--- a/core/auto_process/tv.py
+++ b/core/auto_process/tv.py
@@ -95,12 +95,13 @@ def process(section, dir_name, input_name=None, failed=False, client_agent='manu
     # Attempt to create the directory if it doesn't exist and ignore any
     # error stating that it already exists. This fixes a bug where SickRage
     # won't process the directory because it doesn't exist.
-    try:
-        os.makedirs(dir_name)  # Attempt to create the directory
-    except OSError as e:
-        # Re-raise the error if it wasn't about the directory not existing
-        if e.errno != errno.EEXIST:
-            raise
+    if dir_name:
+        try:
+            os.makedirs(dir_name)  # Attempt to create the directory
+        except OSError as e:
+            # Re-raise the error if it wasn't about the directory not existing
+            if e.errno != errno.EEXIST:
+                raise
 
     if 'process_method' not in fork_params or (client_agent in ['nzbget', 'sabnzbd'] and nzb_extraction_by != 'Destination'):
         if input_name:


### PR DESCRIPTION
# Description

Don't try and create an empty directory for failed downloads.

Fixes #1673 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
