### PR TITLE
Added missing ffmpeg settings to nzbToRadarr and nzbToNzbDrone

### DIFF
--- a/nzbToNzbDrone.py
+++ b/nzbToNzbDrone.py
@@ -102,8 +102,8 @@
 
 # Niceness for external tasks Extractor and Transcoder.
 #
-# Set the Niceness value for the nice command. These range from -20 (most favorable to the process) to 19 (least favorable to the process). 
-# If entering an integer e.g 'niceness=4', this is added to the nice command and passed as 'nice -n4' (Default). 
+# Set the Niceness value for the nice command. These range from -20 (most favorable to the process) to 19 (least favorable to the process).
+# If entering an integer e.g 'niceness=4', this is added to the nice command and passed as 'nice -n4' (Default).
 # If entering a comma separated list e.g. 'niceness=nice,4' this will be passed as 'nice 4' (Safer).
 #niceness=nice,-n0
 
@@ -208,22 +208,25 @@
 # ffmpeg output settings.
 #outputVideoExtension=.mp4
 #outputVideoCodec=libx264
-#VideoCodecAllow =
+#VideoCodecAllow=
 #outputVideoResolution=720:-1
 #outputVideoPreset=medium
 #outputVideoFramerate=24
 #outputVideoBitrate=800k
-#outputAudioCodec=libmp3lame
-#AudioCodecAllow =
-#outputAudioBitrate=128k
-#outputQualityPercent = 0
-#outputAudioTrack2Codec = libfaac
-#AudioCodec2Allow =
-#outputAudioTrack2Bitrate = 128k
-#outputAudioOtherCodec = libmp3lame
-#AudioOtherCodecAllow =
-#outputAudioOtherBitrate = 128k
-#outputSubtitleCodec =
+#outputAudioCodec=ac3
+#AudioCodecAllow=
+#outputAudioChannels=6
+#outputAudioBitrate=640k
+#outputQualityPercent=
+#outputAudioTrack2Codec=libfaac
+#AudioCodec2Allow=
+#outputAudioTrack2Channels=2
+#outputAudioTrack2Bitrate=160k
+#outputAudioOtherCodec=libmp3lame
+#AudioOtherCodecAllow=
+#outputAudioOtherChannels=2
+#outputAudioOtherBitrate=128k
+#outputSubtitleCodec=
 
 ## WakeOnLan
 

--- a/nzbToRadarr.py
+++ b/nzbToRadarr.py
@@ -107,8 +107,8 @@
 
 # Niceness for external tasks Extractor and Transcoder.
 #
-# Set the Niceness value for the nice command. These range from -20 (most favorable to the process) to 19 (least favorable to the process). 
-# If entering an integer e.g 'niceness=4', this is added to the nice command and passed as 'nice -n4' (Default). 
+# Set the Niceness value for the nice command. These range from -20 (most favorable to the process) to 19 (least favorable to the process).
+# If entering an integer e.g 'niceness=4', this is added to the nice command and passed as 'nice -n4' (Default).
 # If entering a comma separated list e.g. 'niceness=nice,4' this will be passed as 'nice 4' (Safer).
 #niceness=nice,-n0
 
@@ -213,22 +213,25 @@
 # ffmpeg output settings.
 #outputVideoExtension=.mp4
 #outputVideoCodec=libx264
-#VideoCodecAllow =
+#VideoCodecAllow=
 #outputVideoResolution=720:-1
 #outputVideoPreset=medium
 #outputVideoFramerate=24
 #outputVideoBitrate=800k
-#outputAudioCodec=libmp3lame
-#AudioCodecAllow =
-#outputAudioBitrate=128k
-#outputQualityPercent = 0
-#outputAudioTrack2Codec = libfaac
-#AudioCodec2Allow =
-#outputAudioTrack2Bitrate = 128k
-#outputAudioOtherCodec = libmp3lame
-#AudioOtherCodecAllow =
-#outputAudioOtherBitrate = 128k
-#outputSubtitleCodec =
+#outputAudioCodec=ac3
+#AudioCodecAllow=
+#outputAudioChannels=6
+#outputAudioBitrate=640k
+#outputQualityPercent=
+#outputAudioTrack2Codec=libfaac
+#AudioCodec2Allow=
+#outputAudioTrack2Channels=2
+#outputAudioTrack2Bitrate=160k
+#outputAudioOtherCodec=libmp3lame
+#AudioOtherCodecAllow=
+#outputAudioOtherChannels=2
+#outputAudioOtherBitrate=128k
+#outputSubtitleCodec=
 
 ## WakeOnLan
 


### PR DESCRIPTION
# Description

When setting up nzbToMedia in nzbGet I noticed the outputAudioChannels options missing. So I copied the values from nzbToMedia to these files.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Since these options are available in other scripts I assume it will work...

**Test Configuration**:

# Checklist:
- [x] I have based this change on the nightly branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
