### PR TITLE
Fix for failed passed as 2,3 from SAB

### DIFF
--- a/core/auto_process/tv.py
+++ b/core/auto_process/tv.py
@@ -188,6 +188,8 @@ def process(section, dir_name, input_name=None, failed=False, client_agent='manu
 
     for param in copy.copy(fork_params):
         if param == 'failed':
+            if failed > 1:
+                failed = 1
             fork_params[param] = failed
             if 'proc_type' in fork_params:
                 del fork_params['proc_type']


### PR DESCRIPTION
# Description

In case where media files aren't checked by nzbToMedia, and SAB sends us status as 2 or 3, force the failed flag to 1.

Fixes #1774

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
