### PR TITLE
No status change error suppression

### DIFF
--- a/autoProcessMedia.cfg.spec
+++ b/autoProcessMedia.cfg.spec
@@ -68,6 +68,8 @@
         method = renamer
         delete_failed = 0
         wait_for = 2
+        # Set this to supress error if no status change after rename called.
+        no_status_check = 0
         extract = 1
         # Set this to minimum required size to consider a media file valid (in MB)
         minSize = 0

--- a/autoProcessMedia.cfg.spec
+++ b/autoProcessMedia.cfg.spec
@@ -68,7 +68,7 @@
         method = renamer
         delete_failed = 0
         wait_for = 2
-        # Set this to supress error if no status change after rename called.
+        # Set this to suppress error if no status change after rename called
         no_status_check = 0
         extract = 1
         # Set this to minimum required size to consider a media file valid (in MB)

--- a/core/auto_process/movies.py
+++ b/core/auto_process/movies.py
@@ -59,6 +59,7 @@ def process(section, dir_name, input_name=None, status=0, client_agent='manual',
     remote_path = int(cfg.get('remote_path', 0))
     protocol = 'https://' if ssl else 'http://'
     omdbapikey = cfg.get('omdbapikey', '')
+    no_status_check = int(cfg.get('no_status_check', 0))
     status = int(status)
     if status > 0 and core.NOEXTRACTFAILED:
         extract = 0
@@ -465,6 +466,11 @@ def process(section, dir_name, input_name=None, status=0, client_agent='manual',
         '{0} does not appear to have changed status after {1} minutes, Please check your logs.'.format(input_name, wait_for),
         section,
     )
+    if no_status_check:
+        return ProcessResult(
+            status_code=0,
+            message='{0}: Successfully processed but no change in status confirmed'.format(section),
+        )    
     return ProcessResult(
         status_code=1,
         message='{0}: Failed to post-process - No change in status'.format(section),


### PR DESCRIPTION
# Description

Suppress the error when CouchPotato we can't determine the release within CouchPotato and are therefore unable to confirm successful status change/rename.

Particularly relevant when using hard-links and therefore the source files are not removed. Setting option no_status_check = 1 will prevent these marking the download as failed.

Fixes #1192 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
