### PR TITLE
Use Response.text instead of Response.content

### DIFF
--- a/core/auto_process/comics.py
+++ b/core/auto_process/comics.py
@@ -76,7 +76,7 @@ def process(section, dir_name, input_name=None, status=0, client_agent='manual',
             status_code=1,
         )
 
-    result = r.content
+    result = r.text
     if not type(result) == list:
         result = result.split('\n')
     for line in result:


### PR DESCRIPTION
# Description

In the comics module, requests is used to communicate with mylar. Previously the `content` from the response is read, and splitted by `\n`. Unfortunately `content` returns a bytes object, that cannot be splitted by a string. This always leads to failure (an exception). One possible fix is, to use the build-in decoding from `requests` and read the `text` from the response. This is a string and can be splitted by `\n`

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested by calling nzbtomedia with mylar. While previously it threw an exception, it now works.

**Test Configuration**:

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
