### PR TITLE
Fix fork recognition when defined in cfg. #1839

### DIFF
--- a/core/auto_process/managers/sickbeard.py
+++ b/core/auto_process/managers/sickbeard.py
@@ -93,9 +93,9 @@ class InitSickBeard(object):
         _val = cfg.get('fork', 'auto')
         f1 = replace.get(_val.lower(), _val)
         try:
-            fork = f1, core.FORKS[f1]
+            self.fork = f1, core.FORKS[f1]
         except KeyError:
-            fork = 'auto'
+            self.fork = 'auto'
         protocol = 'https://' if self.ssl else 'http://'
 
         if self.section == 'NzbDrone':
@@ -115,7 +115,7 @@ class InitSickBeard(object):
                                'Check your configuration'.format
                                (section=self.section, category=self.input_category))
 
-            fork = ['default', {}]
+            self.fork = ['default', {}]
 
         elif self.section == 'SiCKRAGE':
             logger.info('Attempting to verify {category} fork'.format
@@ -163,9 +163,9 @@ class InitSickBeard(object):
                 'is_priority': None
             }
 
-            fork = ['default', params]
+            self.fork = ['default', params]
 
-        elif fork == 'auto':
+        elif self.fork == 'auto':
             self.detect_fork()
 
         logger.info('{section}:{category} fork set to {fork}'.format


### PR DESCRIPTION
# Description

Recent fix to auto-fork caused an issue when the fork is defined in the cfg. this fixes that issue.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

User verified.

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
