### PR TITLE
Fix issue with no Require_lan set #1856 (#1892)

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -398,7 +398,7 @@ def configure_general():
     FFMPEG_PATH = CFG['General']['ffmpeg_path']
     SYS_PATH = CFG['General']['sys_path']
     CHECK_MEDIA = int(CFG['General']['check_media'])
-    REQUIRE_LAN = CFG['General']['require_lan'].split(',') or None
+    REQUIRE_LAN = None if not CFG['General']['require_lan'] else CFG['General']['require_lan'].split(',')
     SAFE_MODE = int(CFG['General']['safe_mode'])
     NOEXTRACTFAILED = int(CFG['General']['no_extract_failed'])
 


### PR DESCRIPTION
Thanks @BradKollmyer

# Description

A split of an empty string will return a list of [''] and return this for the assignment. So the default '' value will not set this as None but rather a single empty string.

Fixes #1856 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

User verified.

**Test Configuration**:

# Checklist:
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
















