### PR TITLE
Switch `rem_id` to a Set to prevent duplicates.

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -125,7 +125,7 @@ ALL_FORKS = {k: None for k in set(list(itertools.chain.from_iterable([FORKS[x].k
 
 # SiCKRAGE OAuth2
 SICKRAGE_OAUTH_CLIENT_ID = 'nzbtomedia'
-SICKRAGE_OAUTH_TOKEN_URL = 'https://auth.sickrage.ca/auth/realms/sickrage/protocol/openid-connect/token'
+SICKRAGE_OAUTH_TOKEN_URL = 'https://auth.sickrage.ca/realms/sickrage/protocol/openid-connect/token'
 
 # NZBGet Exit Codes
 NZBGET_POSTPROCESS_PAR_CHECK = 92

--- a/core/auto_process/movies.py
+++ b/core/auto_process/movies.py
@@ -563,12 +563,12 @@ def get_release(base_url, imdb_id=None, download_id=None, release_id=None):
 
     # Narrow results by removing old releases by comparing their last_edit field
     if len(results) > 1:
-        rem_id = []
+        rem_id = set()
         for id1, x1 in results.items():
             for x2 in results.values():
                 try:
                     if x2['last_edit'] > x1['last_edit']:
-                        rem_id.append(id1)
+                        rem_id.add(id1)
                 except Exception:
                     continue
         for id in rem_id:
@@ -576,11 +576,11 @@ def get_release(base_url, imdb_id=None, download_id=None, release_id=None):
 
     # Search downloads on clients for a match to try and narrow our results down to 1
     if len(results) > 1:
-        rem_id = []
+        rem_id = set()
         for cur_id, x in results.items():
             try:
                 if not find_download(str(x['download_info']['downloader']).lower(), x['download_info']['id']):
-                    rem_id.append(cur_id)
+                    rem_id.add(cur_id)
             except Exception:
                 continue
         for id in rem_id:


### PR DESCRIPTION
# Description

Fix minor bug in get_release.
  - Switch `rem_id` to a Set to prevent duplicates.

Fixes # [1894](https://github.com/clinton-hall/nzbToMedia/issues/1894)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I downloaded a file and post processed it with nzbToMedia. It failed without the change, and works with it.

**Test Configuration**:

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
