### PR TITLE
Add Python 3.11 end-of-life date

### DIFF
--- a/eol.py
+++ b/eol.py
@@ -28,6 +28,7 @@ def date(string, fmt='%Y-%m-%d'):
 # https://devguide.python.org/
 # https://devguide.python.org/devcycle/#devcycle
 PYTHON_EOL = {
+    (3, 11): date('2027-10-1'),
     (3, 10): date('2026-10-01'),
     (3, 9): date('2025-10-05'),
     (3, 8): date('2024-10-14'),


### PR DESCRIPTION
# Description

Adds Python 3.11 to end-of-life date
Fixes #1901

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code

- **Not applicable (simple change):** I have commented my code, particularly in hard-to-understand areas
- **Not applicable (python 3.11 not yet supported):** I have made corresponding changes to the documentation
- **Not applicable (python 3.11 not yet supported):** I have added tests that prove my fix is effective or that my feature works 
- **Not applicable (python 3.11 not yet supported):** New and existing unit tests pass locally with my changes
