### PR TITLE
Remove Python 2.7 from `requirements.txt`

### DIFF
--- a/libs/requirements.txt
+++ b/libs/requirements.txt
@@ -1,3 +1,2 @@
 -r requirements-common.txt
--r requirements-py2.txt ; python_version < '3'
 -r requirements-win.txt ; sys.platform == 'win32'


### PR DESCRIPTION
Removes Python 2.7 from `requirements.txt`