### PR TITLE
Drop legacy Python 2.7 constructs

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import subprocess
 import sys

--- a/cleanup.py
+++ b/cleanup.py
@@ -30,7 +30,7 @@ FOLDER_STRUCTURE = {
 }
 
 
-class WorkingDirectory(object):
+class WorkingDirectory:
     """Context manager for changing current working directory."""
 
     def __init__(self, new, original=None):

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import itertools
 import locale
 import os

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import itertools
 import locale
 import os

--- a/core/auto_process/books.py
+++ b/core/auto_process/books.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import requests
 
 import core

--- a/core/auto_process/books.py
+++ b/core/auto_process/books.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import requests
 
 import core

--- a/core/auto_process/comics.py
+++ b/core/auto_process/comics.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 
 import requests

--- a/core/auto_process/comics.py
+++ b/core/auto_process/comics.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 
 import requests

--- a/core/auto_process/common.py
+++ b/core/auto_process/common.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import requests
 
 from core import logger

--- a/core/auto_process/common.py
+++ b/core/auto_process/common.py
@@ -10,7 +10,7 @@ import requests
 from core import logger
 
 
-class ProcessResult(object):
+class ProcessResult:
     def __init__(self, message, status_code):
         self.message = message
         self.status_code = status_code

--- a/core/auto_process/games.py
+++ b/core/auto_process/games.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 import shutil
 

--- a/core/auto_process/games.py
+++ b/core/auto_process/games.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import shutil
 

--- a/core/auto_process/managers/sickbeard.py
+++ b/core/auto_process/managers/sickbeard.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import copy
 
 import core

--- a/core/auto_process/managers/sickbeard.py
+++ b/core/auto_process/managers/sickbeard.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import copy
 
 import core

--- a/core/auto_process/managers/sickbeard.py
+++ b/core/auto_process/managers/sickbeard.py
@@ -26,7 +26,7 @@ import six
 from six import iteritems
 
 
-class InitSickBeard(object):
+class InitSickBeard:
     """Sickbeard init class.
 
     Used to determin which sickbeard fork object to initialize.
@@ -316,7 +316,7 @@ class InitSickBeard(object):
             )
 
 
-class SickBeard(object):
+class SickBeard:
     """Sickbeard base class."""
 
     def __init__(self, sb_init):

--- a/core/auto_process/movies.py
+++ b/core/auto_process/movies.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import json
 import os
 import time

--- a/core/auto_process/movies.py
+++ b/core/auto_process/movies.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import json
 import os
 import time

--- a/core/auto_process/music.py
+++ b/core/auto_process/music.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import json
 import os
 import time

--- a/core/auto_process/music.py
+++ b/core/auto_process/music.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import json
 import os
 import time

--- a/core/auto_process/tv.py
+++ b/core/auto_process/tv.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import copy
 import errno
 import json

--- a/core/auto_process/tv.py
+++ b/core/auto_process/tv.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import copy
 import errno
 import json

--- a/core/configuration.py
+++ b/core/configuration.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import copy
 import os
 import shutil

--- a/core/configuration.py
+++ b/core/configuration.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import copy
 import os
 import shutil

--- a/core/databases.py
+++ b/core/databases.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from core import logger, main_db
 from core.utils import backup_versioned_file
 

--- a/core/databases.py
+++ b/core/databases.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from core import logger, main_db
 from core.utils import backup_versioned_file
 

--- a/core/extractor/__init__.py
+++ b/core/extractor/__init__.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import platform
 import shutil

--- a/core/extractor/__init__.py
+++ b/core/extractor/__init__.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 import platform
 import shutil

--- a/core/github_api.py
+++ b/core/github_api.py
@@ -10,7 +10,7 @@ from __future__ import (
 import requests
 
 
-class GitHub(object):
+class GitHub:
     """Simple api wrapper for the Github API v3."""
 
     def __init__(self, github_repo_user, github_repo, branch='master'):

--- a/core/github_api.py
+++ b/core/github_api.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import requests
 
 

--- a/core/github_api.py
+++ b/core/github_api.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import requests
 
 

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import logging
 import os
 import sys

--- a/core/logger.py
+++ b/core/logger.py
@@ -36,7 +36,7 @@ reverseNames = {u'ERROR': ERROR,
                 u'DB': DB}
 
 
-class NTMRotatingLogHandler(object):
+class NTMRotatingLogHandler:
     def __init__(self, log_file, num_files, num_bytes):
         self.num_files = num_files
         self.num_bytes = num_bytes
@@ -240,7 +240,7 @@ class NTMRotatingLogHandler(object):
             sys.exit(1)
 
 
-class DispatchingFormatter(object):
+class DispatchingFormatter:
     def __init__(self, formatters, default_formatter):
         self._formatters = formatters
         self._default_formatter = default_formatter

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import logging
 import os
 import sys

--- a/core/main_db.py
+++ b/core/main_db.py
@@ -58,7 +58,7 @@ def db_filename(filename='nzbtomedia.db', suffix=None):
     return core.os.path.join(core.APP_ROOT, filename)
 
 
-class DBConnection(object):
+class DBConnection:
     def __init__(self, filename='nzbtomedia.db', suffix=None, row_type=None):
 
         self.filename = filename
@@ -242,7 +242,7 @@ def sanity_check_database(connection, sanity_check):
     sanity_check(connection).check()
 
 
-class DBSanityCheck(object):
+class DBSanityCheck:
     def __init__(self, connection):
         self.connection = connection
 
@@ -287,7 +287,7 @@ def _process_upgrade(connection, upgrade_class):
 
 
 # Base migration class. All future DB changes should be subclassed from this class
-class SchemaUpgrade(object):
+class SchemaUpgrade:
     def __init__(self, connection):
         self.connection = connection
 

--- a/core/main_db.py
+++ b/core/main_db.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import re
 import sqlite3
 import time
@@ -34,7 +32,6 @@ if PY2:
             return super(Row, self).__getitem__(item)
 else:
     from sqlite3 import Row
-
 
 def db_filename(filename='nzbtomedia.db', suffix=None):
     """

--- a/core/main_db.py
+++ b/core/main_db.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import re
 import sqlite3
 import time

--- a/core/plugins/downloaders/nzb/configuration.py
+++ b/core/plugins/downloaders/nzb/configuration.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import core
 
 

--- a/core/plugins/downloaders/nzb/utils.py
+++ b/core/plugins/downloaders/nzb/utils.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 
 import requests

--- a/core/plugins/downloaders/torrent/configuration.py
+++ b/core/plugins/downloaders/torrent/configuration.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import core
 from core.plugins.downloaders.torrent.utils import create_torrent_class
 

--- a/core/plugins/downloaders/torrent/deluge.py
+++ b/core/plugins/downloaders/torrent/deluge.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from deluge_client.client import DelugeRPCClient
 
 import core

--- a/core/plugins/downloaders/torrent/qbittorrent.py
+++ b/core/plugins/downloaders/torrent/qbittorrent.py
@@ -1,11 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
-
 from qbittorrent import Client as qBittorrentClient
 
 import core

--- a/core/plugins/downloaders/torrent/synology.py
+++ b/core/plugins/downloaders/torrent/synology.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from syno.downloadstation import DownloadStation
 
 import core

--- a/core/plugins/downloaders/torrent/transmission.py
+++ b/core/plugins/downloaders/torrent/transmission.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from transmissionrpc.client import Client as TransmissionClient
 
 import core

--- a/core/plugins/downloaders/torrent/utils.py
+++ b/core/plugins/downloaders/torrent/utils.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import time
 
 import core

--- a/core/plugins/downloaders/torrent/utorrent.py
+++ b/core/plugins/downloaders/torrent/utorrent.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from utorrent.client import UTorrentClient
 
 import core

--- a/core/plugins/plex.py
+++ b/core/plugins/plex.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import requests
 
 import core

--- a/core/plugins/subtitles.py
+++ b/core/plugins/subtitles.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from babelfish import Language
 import subliminal
 

--- a/core/scene_exceptions.py
+++ b/core/scene_exceptions.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import platform
 import re

--- a/core/scene_exceptions.py
+++ b/core/scene_exceptions.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 import platform
 import re

--- a/core/transcoder.py
+++ b/core/transcoder.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import errno
 import json
 import sys

--- a/core/transcoder.py
+++ b/core/transcoder.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import errno
 import json
 import sys

--- a/core/user_scripts.py
+++ b/core/user_scripts.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 from subprocess import Popen
 

--- a/core/user_scripts.py
+++ b/core/user_scripts.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 from subprocess import Popen
 
@@ -10,7 +8,6 @@ from core.utils import list_media_files, remove_dir
 from core.auto_process.common import (
     ProcessResult,
 )
-
 
 
 def external_script(output_destination, torrent_name, torrent_label, settings):

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,12 +1,5 @@
 # coding=utf-8
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import requests
 
 from core.utils import shutil_custom

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import requests
 
 from core.utils import shutil_custom

--- a/core/utils/common.py
+++ b/core/utils/common.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os.path
 
 from six import text_type

--- a/core/utils/download_info.py
+++ b/core/utils/download_info.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import datetime
 
 from six import text_type

--- a/core/utils/encoding.py
+++ b/core/utils/encoding.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 
 from six import text_type

--- a/core/utils/files.py
+++ b/core/utils/files.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import re
 import shutil

--- a/core/utils/identification.py
+++ b/core/utils/identification.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import re
 

--- a/core/utils/links.py
+++ b/core/utils/links.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import shutil
 

--- a/core/utils/naming.py
+++ b/core/utils/naming.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import re
 
 

--- a/core/utils/network.py
+++ b/core/utils/network.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import socket
 import struct
 import time

--- a/core/utils/parsers.py
+++ b/core/utils/parsers.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 
 import core

--- a/core/utils/paths.py
+++ b/core/utils/paths.py
@@ -1,10 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 from functools import partial
 import os
 import re

--- a/core/utils/processes.py
+++ b/core/utils/processes.py
@@ -19,7 +19,7 @@ if os.name == 'nt':
     from winerror import ERROR_ALREADY_EXISTS
 
 
-class WindowsProcess(object):
+class WindowsProcess:
     def __init__(self):
         self.mutex = None
         self.mutexname = 'nzbtomedia_{pid}'.format(pid=core.PID_FILE.replace('\\', '/'))  # {D0E858DF-985E-4907-B7FB-8D732C3FC3B9}'
@@ -42,7 +42,7 @@ class WindowsProcess(object):
             self.CloseHandle(self.mutex)
 
 
-class PosixProcess(object):
+class PosixProcess:
     def __init__(self):
         self.pidpath = core.PID_FILE
         self.lock_socket = None

--- a/core/utils/processes.py
+++ b/core/utils/processes.py
@@ -1,9 +1,3 @@
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
 
 import os
 import socket

--- a/core/version_check.py
+++ b/core/version_check.py
@@ -2,13 +2,6 @@
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # Modified by: echel0n
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import os
 import platform
 import re

--- a/core/version_check.py
+++ b/core/version_check.py
@@ -25,7 +25,7 @@ import core
 from core import github_api as github, logger
 
 
-class CheckVersion(object):
+class CheckVersion:
     """Version checker that runs in a thread with the SB scheduler."""
 
     def __init__(self):
@@ -88,7 +88,7 @@ class CheckVersion(object):
             return result
 
 
-class UpdateManager(object):
+class UpdateManager:
     def get_github_repo_user(self):
         return core.GIT_USER
 

--- a/core/version_check.py
+++ b/core/version_check.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # Modified by: echel0n
 

--- a/eol.py
+++ b/eol.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import (
-    absolute_import,
-    division,
-    print_function,
-    unicode_literals,
-)
-
 import datetime
 import sys
 import warnings


### PR DESCRIPTION
# Description

- All classes are new style classes in Python 3
- Removed `__future__` imports are default in Python 3
- `.py` files are UTF-8 by default in Python 3
