### PR TITLE
Sickbeard

### DIFF
--- a/core/auto_process/managers/sickbeard.py
+++ b/core/auto_process/managers/sickbeard.py
@@ -432,7 +432,7 @@ class SickBeard:
         # delete any unused params so we don't pass them to SB by mistake
         [fork_params.pop(k) for k, v in list(fork_params.items()) if v is None]
 
-    def api_call(self):
+    def api_call(self) -> ProcessResult:
         """Perform a base sickbeard api call."""
         self._process_fork_prarams()
         logger.debug(f'Opening URL: {self.url} with params: {self.sb_init.fork_params}', self.sb_init.section)
@@ -468,7 +468,7 @@ class SickBeard:
 
         return self.process_response(response)
 
-    def process_response(self, response):
+    def process_response(self, response: requests.Response) -> ProcessResult:
         """Iterate over the lines returned, and log.
 
         :param response: Streamed Requests response object.

--- a/core/auto_process/managers/sickbeard.py
+++ b/core/auto_process/managers/sickbeard.py
@@ -454,16 +454,16 @@ class SickBeard:
             response = self.session.get(self.url, auth=(self.sb_init.username, self.sb_init.password), params=self.sb_init.fork_params, stream=True, verify=False, timeout=(30, 1800))
         except requests.ConnectionError:
             logger.error(f'Unable to open URL: {self.url}', self.sb_init.section)
-            return ProcessResult(
-                message='{0}: Failed to post-process - Unable to connect to {0}'.format(self.sb_init.section),
-                status_code=1,
+            return ProcessResult.failure(
+                f'{self.sb_init.section}: Failed to post-process - Unable to '
+                f'connect to {self.sb_init.section}'
             )
 
         if response.status_code not in [requests.codes.ok, requests.codes.created, requests.codes.accepted]:
             logger.error('Server returned status {0}'.format(response.status_code), self.sb_init.section)
-            return ProcessResult(
-                message='{0}: Failed to post-process - Server returned status {1}'.format(self.sb_init.section, response.status_code),
-                status_code=1,
+            return ProcessResult.failure(
+                f'{self.sb_init.section}: Failed to post-process - Server '
+                f'returned status {response.status_code}'
             )
 
         return self.process_response(response)
@@ -487,11 +487,13 @@ class SickBeard:
                     self.success = True
 
         if self.success:
-            return ProcessResult(
-                message='{0}: Successfully post-processed {1}'.format(self.sb_init.section, self.input_name),
-                status_code=0,
+            return ProcessResult.success(
+                f'{self.sb_init.section}: Successfully post-processed '
+                f'{self.input_name}'
             )
-        return ProcessResult(
-            message='{0}: Failed to post-process - Returned log from {0} was not as expected.'.format(self.sb_init.section),
-            status_code=1,  # We did not receive Success confirmation.
+
+        # We did not receive Success confirmation.
+        return ProcessResult.failure(
+            f'{self.sb_init.section}: Failed to post-process - Returned log '
+            f'from {self.sb_init.section} was not as expected.'
         )


### PR DESCRIPTION
# Description

- Use `ProcessResult.failure` or `ProcessResult.success`
- Use f-strings
- Add type-hints
- Reduce number of return paths