### PR TITLE
Don't disable urllib3 warnings

### DIFF
--- a/core/auto_process/books.py
+++ b/core/auto_process/books.py
@@ -32,9 +32,6 @@ from core.utils.paths import remove_dir
 from core.utils.network import server_responding
 
 
-requests.packages.urllib3.disable_warnings()
-
-
 def process(
     *,
     section: str,

--- a/core/auto_process/comics.py
+++ b/core/auto_process/comics.py
@@ -32,9 +32,6 @@ from core.utils.paths import remove_dir
 from core.utils.network import server_responding
 
 
-requests.packages.urllib3.disable_warnings()
-
-
 def process(
     *,
     section: str,

--- a/core/auto_process/games.py
+++ b/core/auto_process/games.py
@@ -32,9 +32,6 @@ from core.utils.paths import remove_dir
 from core.utils.network import server_responding
 
 
-requests.packages.urllib3.disable_warnings()
-
-
 def process(
     *,
     section: str,

--- a/core/auto_process/music.py
+++ b/core/auto_process/music.py
@@ -32,9 +32,6 @@ from core.utils.paths import remove_dir
 from core.utils.network import server_responding
 
 
-requests.packages.urllib3.disable_warnings()
-
-
 def process(
     *,
     section: str,

--- a/core/auto_process/tv.py
+++ b/core/auto_process/tv.py
@@ -32,9 +32,6 @@ from core.utils.paths import remove_dir
 from core.utils.network import server_responding
 
 
-requests.packages.urllib3.disable_warnings()
-
-
 def process(
     *,
     section: str,


### PR DESCRIPTION
If needed we can selectively catch desired warnings at the point required.  This method is overly broad.