### PR TITLE
Initialize remove_groups #1973

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1047,6 +1047,7 @@ def initialize(section=None):
     configure_utility_locations()
     configure_sections(section)
     configure_torrent_class()
+    configure_groups()
 
     __INITIALIZED__ = True
 


### PR DESCRIPTION
remove_groups parameter was not being loaded and therefore was ignored.
This fixes that issue.

Fixes #1973 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

User verified.

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
