### PR TITLE
added global ignore flag for bytecode cleanup

### DIFF
--- a/cleanup.py
+++ b/cleanup.py
@@ -116,6 +116,7 @@ def clean_bytecode():
         result = git_clean(
             remove_directories=True,
             force=True,
+            ignore_rules=True,
             exclude=[
                 '*.*',  # exclude everything
                 '!*.py[co]',  # except bytecode


### PR DESCRIPTION
Resolves #1867

# Description

This keeps git from looking for global ignore directory especially when it doesn't exist (which throws a scary looking warning)

Fixes #1867 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Made the change locally, successfully postprocessed without the error

**Test Configuration**:

# Checklist:
- [ ] I have based this change on the nightly branch
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
