### PR TITLE
class not added yet put into debug logging

### DIFF
--- a/core/auto_process/managers/sickbeard.py
+++ b/core/auto_process/managers/sickbeard.py
@@ -311,7 +311,7 @@ class InitSickBeard(object):
             # Create the fork object and pass self (SickBeardInit) to it for all the data, like Config.
             self.fork_obj = mapped_forks[self.fork](self)
         else:
-            logger.info('{section}:{category} Could not create a fork object for {fork}. Probaly class not added yet.'.format(
+            logger.debug('{section}:{category} Could not create a fork object for {fork}. Probaly class not added yet.'.format(
                 section=self.section, category=self.input_category, fork=self.fork)
             )
 


### PR DESCRIPTION
# Description

Removes the class not added yet from info logging and puts this in debug logging only.

Fixes #1992

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [X] I have based this change on the nightly branch
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
