### PR TITLE
add python 3.14 to EOL lookup

### DIFF
--- a/eol.py
+++ b/eol.py
@@ -28,6 +28,7 @@ def date(string, fmt='%Y-%m-%d'):
 # https://devguide.python.org/
 # https://devguide.python.org/devcycle/#devcycle
 PYTHON_EOL = {
+    (3, 14): date('2030-10-1'),
     (3, 13): date('2029-10-1'),
     (3, 12): date('2028-10-1'),
     (3, 11): date('2027-10-1'),

--- a/eol.py
+++ b/eol.py
@@ -27,6 +27,7 @@ def date(string, fmt='%Y-%m-%d'):
 
 # https://devguide.python.org/
 # https://devguide.python.org/devcycle/#devcycle
+# https://devguide.python.org/versions/#supported-versions
 PYTHON_EOL = {
     (3, 14): date('2030-10-1'),
     (3, 13): date('2029-10-1'),


### PR DESCRIPTION
# TL;DR
- Arch Linux updated their Python to 3.14 on January 3, 2026
- With Arch Linux and `pacman`, [partial upgrades are unsupported](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported) , so any variant of `pacman -Syu` upgrades **_everything_**
- Add an End of Life (EOL) lookup in `eol.py` for  `(3, 14)` (i.e. Python 3.14)

# Description

Arch Linux's [python](https://archlinux.org/packages/core/x86_64/python/) package updated to Python 3.14 [early this month](https://www.reddit.com/r/archlinux/comments/1q3o9ri/latest_python_upgrade_313_314_on_jan_3_2026/):

<img width="679" height="339" alt="Screenshot 2026-01-19 at 4 59 36 PM" src="https://github.com/user-attachments/assets/0641075a-463f-4f27-a0c7-d1f2875cecbe" />

which breaks the end of life check in `eol.py`, simply because there's no mapping.

EOL date derived from chart in [Status of Python versions > Supported versions](https://devguide.python.org/versions/#supported-versions):

<img width="1488" height="1111" alt="Screenshot 2026-01-19 at 5 11 17 PM" src="https://github.com/user-attachments/assets/114f84d7-5cbd-4dcd-919d-2924f8f74e36" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Ran this change on my machine for the last week without any errors.

**Test Configuration**:

# Checklist:
- [x] I have based this change on the nightly branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
